### PR TITLE
Rename mock properties and add missing mock properties

### DIFF
--- a/Sources/Mocked/MockFunctions/MockReturningFunctions/MockReturningAsyncFunctionWithParameters.swift
+++ b/Sources/Mocked/MockFunctions/MockReturningFunctions/MockReturningAsyncFunctionWithParameters.swift
@@ -22,17 +22,17 @@ public final class MockReturningAsyncFunctionWithParameters<Arguments, ReturnVal
     /// All the arguments with which the function has been invoked.
     public private(set) var invocations: [Arguments] = []
 
-    /// The latest arguments with which the function has been invoked.
-    public var latestInvocation: Arguments? {
+    /// The last arguments with which the function has been invoked.
+    public var lastInvocation: Arguments? {
         self.invocations.last
     }
 
     /// All the values that have been returned by the function.
-    public private(set) var returnValues: [ReturnValue] = []
+    public private(set) var returnedValues: [ReturnValue] = []
 
-    /// The latest value returned by the function.
-    public var latestReturnValue: ReturnValue? {
-        self.returnValues.last
+    /// The last value returned by the function.
+    public var lastReturnedValue: ReturnValue? {
+        self.returnedValues.last
     }
 
     /// The description of the mock's exposed function.
@@ -108,7 +108,7 @@ public final class MockReturningAsyncFunctionWithParameters<Arguments, ReturnVal
 
         let returnValue = await self.implementation(description: self.exposedFunctionDescription)
 
-        self.returnValues.append(returnValue)
+        self.returnedValues.append(returnValue)
 
         return returnValue
     }

--- a/Sources/Mocked/MockFunctions/MockReturningFunctions/MockReturningAsyncFunctionWithoutParameters.swift
+++ b/Sources/Mocked/MockFunctions/MockReturningFunctions/MockReturningAsyncFunctionWithoutParameters.swift
@@ -20,11 +20,11 @@ public final class MockReturningAsyncFunctionWithoutParameters<ReturnValue> {
     public private(set) var callCount: Int = .zero
 
     /// All the values that have been returned by the function.
-    public private(set) var returnValues: [ReturnValue] = []
+    public private(set) var returnedValues: [ReturnValue] = []
 
-    /// The latest value returned by the function.
-    public var latestReturnValue: ReturnValue? {
-        self.returnValues.last
+    /// The last value returned by the function.
+    public var lastReturnedValue: ReturnValue? {
+        self.returnedValues.last
     }
 
     /// The description of the mock's exposed function.
@@ -97,7 +97,7 @@ public final class MockReturningAsyncFunctionWithoutParameters<ReturnValue> {
 
         let returnValue = await self.implementation(description: self.exposedFunctionDescription)
 
-        self.returnValues.append(returnValue)
+        self.returnedValues.append(returnValue)
 
         return returnValue
     }

--- a/Sources/Mocked/MockFunctions/MockReturningFunctions/MockReturningAsyncThrowingFunctionWithParameters.swift
+++ b/Sources/Mocked/MockFunctions/MockReturningFunctions/MockReturningAsyncThrowingFunctionWithParameters.swift
@@ -22,17 +22,17 @@ public final class MockReturningAsyncThrowingFunctionWithParameters<Arguments, R
     /// All the arguments with which the function has been invoked.
     public private(set) var invocations: [Arguments] = []
 
-    /// The latest arguments with which the function has been invoked.
-    public var latestInvocation: Arguments? {
+    /// The last arguments with which the function has been invoked.
+    public var lastInvocation: Arguments? {
         self.invocations.last
     }
 
     /// All the values that have been returned by the function.
-    public private(set) var returnValues: [Result<ReturnValue, Error>] = []
+    public private(set) var returnedValues: [Result<ReturnValue, Error>] = []
 
-    /// The latest value returned by the function.
-    public var latestReturnValue: Result<ReturnValue, Error>? {
-        self.returnValues.last
+    /// The last value returned by the function.
+    public var lastReturnedValue: Result<ReturnValue, Error>? {
+        self.returnedValues.last
     }
 
     /// The description of the mock's exposed function.
@@ -113,7 +113,7 @@ public final class MockReturningAsyncThrowingFunctionWithParameters<Arguments, R
             try await self.implementation(description: self.exposedFunctionDescription)
         }
 
-        self.returnValues.append(returnValue)
+        self.returnedValues.append(returnValue)
 
         return try returnValue.get()
     }

--- a/Sources/Mocked/MockFunctions/MockReturningFunctions/MockReturningAsyncThrowingFunctionWithoutParameters.swift
+++ b/Sources/Mocked/MockFunctions/MockReturningFunctions/MockReturningAsyncThrowingFunctionWithoutParameters.swift
@@ -20,11 +20,11 @@ public final class MockReturningAsyncThrowingFunctionWithoutParameters<ReturnVal
     public private(set) var callCount: Int = .zero
 
     /// All the values that have been returned by the function.
-    public private(set) var returnValues: [Result<ReturnValue, Error>] = []
+    public private(set) var returnedValues: [Result<ReturnValue, Error>] = []
 
-    /// The latest value returned by the function.
-    public var latestReturnValue: Result<ReturnValue, Error>? {
-        self.returnValues.last
+    /// The last value returned by the function.
+    public var lastReturnedValue: Result<ReturnValue, Error>? {
+        self.returnedValues.last
     }
 
     /// The description of the mock's exposed function.
@@ -100,7 +100,7 @@ public final class MockReturningAsyncThrowingFunctionWithoutParameters<ReturnVal
             try await self.implementation(description: self.exposedFunctionDescription)
         }
 
-        self.returnValues.append(returnValue)
+        self.returnedValues.append(returnValue)
 
         return try returnValue.get()
     }

--- a/Sources/Mocked/MockFunctions/MockReturningFunctions/MockReturningFunctionWithParameters.swift
+++ b/Sources/Mocked/MockFunctions/MockReturningFunctions/MockReturningFunctionWithParameters.swift
@@ -22,17 +22,17 @@ public final class MockReturningFunctionWithParameters<Arguments, ReturnValue> {
     /// All the arguments with which the function has been invoked.
     public private(set) var invocations: [Arguments] = []
 
-    /// The latest arguments with which the function has been invoked.
-    public var latestInvocation: Arguments? {
+    /// The last arguments with which the function has been invoked.
+    public var lastInvocation: Arguments? {
         self.invocations.last
     }
 
     /// All the values that have been returned by the function.
-    public private(set) var returnValues: [ReturnValue] = []
+    public private(set) var returnedValues: [ReturnValue] = []
 
-    /// The latest value returned by the function.
-    public var latestReturnValue: ReturnValue? {
-        self.returnValues.last
+    /// The last value returned by the function.
+    public var lastReturnedValue: ReturnValue? {
+        self.returnedValues.last
     }
 
     /// The description of the mock's exposed function.
@@ -108,7 +108,7 @@ public final class MockReturningFunctionWithParameters<Arguments, ReturnValue> {
 
         let returnValue = self.implementation(description: self.exposedFunctionDescription)
 
-        self.returnValues.append(returnValue)
+        self.returnedValues.append(returnValue)
 
         return returnValue
     }

--- a/Sources/Mocked/MockFunctions/MockReturningFunctions/MockReturningFunctionWithoutParameters.swift
+++ b/Sources/Mocked/MockFunctions/MockReturningFunctions/MockReturningFunctionWithoutParameters.swift
@@ -20,11 +20,11 @@ public final class MockReturningFunctionWithoutParameters<ReturnValue> {
     public private(set) var callCount: Int = .zero
 
     /// All the values that have been returned by the function.
-    public private(set) var returnValues: [ReturnValue] = []
+    public private(set) var returnedValues: [ReturnValue] = []
 
-    /// The latest value returned by the function.
-    public var latestReturnValue: ReturnValue? {
-        self.returnValues.last
+    /// The last value returned by the function.
+    public var lastReturnedValue: ReturnValue? {
+        self.returnedValues.last
     }
 
     /// The description of the mock's exposed function.
@@ -97,7 +97,7 @@ public final class MockReturningFunctionWithoutParameters<ReturnValue> {
 
         let returnValue = self.implementation(description: self.exposedFunctionDescription)
 
-        self.returnValues.append(returnValue)
+        self.returnedValues.append(returnValue)
 
         return returnValue
     }

--- a/Sources/Mocked/MockFunctions/MockReturningFunctions/MockReturningThrowingFunctionWithParameters.swift
+++ b/Sources/Mocked/MockFunctions/MockReturningFunctions/MockReturningThrowingFunctionWithParameters.swift
@@ -22,17 +22,17 @@ public final class MockReturningThrowingFunctionWithParameters<Arguments, Return
     /// All the arguments with which the function has been invoked.
     public private(set) var invocations: [Arguments] = []
 
-    /// The latest arguments with which the function has been invoked.
-    public var latestInvocation: Arguments? {
+    /// The last arguments with which the function has been invoked.
+    public var lastInvocation: Arguments? {
         self.invocations.last
     }
 
     /// All the values that have been returned by the function.
-    public private(set) var returnValues: [Result<ReturnValue, Error>] = []
+    public private(set) var returnedValues: [Result<ReturnValue, Error>] = []
 
-    /// The latest value returned by the function.
-    public var latestReturnValue: Result<ReturnValue, Error>? {
-        self.returnValues.last
+    /// The last value returned by the function.
+    public var lastReturnedValue: Result<ReturnValue, Error>? {
+        self.returnedValues.last
     }
 
     /// The description of the mock's exposed function.
@@ -111,7 +111,7 @@ public final class MockReturningThrowingFunctionWithParameters<Arguments, Return
             try self.implementation(description: self.exposedFunctionDescription)
         }
 
-        self.returnValues.append(returnValue)
+        self.returnedValues.append(returnValue)
 
         return try returnValue.get()
     }

--- a/Sources/Mocked/MockFunctions/MockReturningFunctions/MockReturningThrowingFunctionWithoutParameters.swift
+++ b/Sources/Mocked/MockFunctions/MockReturningFunctions/MockReturningThrowingFunctionWithoutParameters.swift
@@ -20,11 +20,11 @@ public final class MockReturningThrowingFunctionWithoutParameters<ReturnValue> {
     public private(set) var callCount: Int = .zero
 
     /// All the values that have been returned by the function.
-    public private(set) var returnValues: [Result<ReturnValue, Error>] = []
+    public private(set) var returnedValues: [Result<ReturnValue, Error>] = []
 
-    /// The latest value returned by the function.
-    public var latestReturnValue: Result<ReturnValue, Error>? {
-        self.returnValues.last
+    /// The last value returned by the function.
+    public var lastReturnedValue: Result<ReturnValue, Error>? {
+        self.returnedValues.last
     }
 
     /// The description of the mock's exposed function.
@@ -100,7 +100,7 @@ public final class MockReturningThrowingFunctionWithoutParameters<ReturnValue> {
             try self.implementation(description: self.exposedFunctionDescription)
         }
 
-        self.returnValues.append(returnValue)
+        self.returnedValues.append(returnValue)
 
         return try returnValue.get()
     }

--- a/Sources/Mocked/MockFunctions/MockVoidFunctions/MockVoidAsyncFunctionWithParameters.swift
+++ b/Sources/Mocked/MockFunctions/MockVoidFunctions/MockVoidAsyncFunctionWithParameters.swift
@@ -19,8 +19,8 @@ public final class MockVoidAsyncFunctionWithParameters<Arguments> {
     /// All the arguments with which the function has been invoked.
     public private(set) var invocations: [Arguments] = []
 
-    /// The latest arguments with which the function has been invoked.
-    public var latestInvocation: Arguments? {
+    /// The last arguments with which the function has been invoked.
+    public var lastInvocation: Arguments? {
         self.invocations.last
     }
 

--- a/Sources/Mocked/MockFunctions/MockVoidFunctions/MockVoidAsyncThrowingFunctionWithParameters.swift
+++ b/Sources/Mocked/MockFunctions/MockVoidFunctions/MockVoidAsyncThrowingFunctionWithParameters.swift
@@ -22,17 +22,17 @@ public final class MockVoidAsyncThrowingFunctionWithParameters<Arguments> {
     /// All the arguments with which the function has been invoked.
     public private(set) var invocations: [Arguments] = []
 
-    /// The latest arguments with which the function has been invoked.
-    public var latestInvocation: Arguments? {
+    /// The last arguments with which the function has been invoked.
+    public var lastInvocation: Arguments? {
         self.invocations.last
     }
 
     /// All the errors that have been thrown by the function.
-    public private(set) var errors: [Error] = []
+    public private(set) var thrownErrors: [Error] = []
 
-    /// The latest error thrown by the function.
-    public var latestError: Error? {
-        self.errors.last
+    /// The last error thrown by the function.
+    public var lastThrownError: Error? {
+        self.thrownErrors.last
     }
 
     // MARK: Initializers
@@ -88,7 +88,7 @@ public final class MockVoidAsyncThrowingFunctionWithParameters<Arguments> {
             return
         }
 
-        self.errors.append(error)
+        self.thrownErrors.append(error)
 
         throw error
     }

--- a/Sources/Mocked/MockFunctions/MockVoidFunctions/MockVoidAsyncThrowingFunctionWithoutParameters.swift
+++ b/Sources/Mocked/MockFunctions/MockVoidFunctions/MockVoidAsyncThrowingFunctionWithoutParameters.swift
@@ -20,11 +20,11 @@ public final class MockVoidAsyncThrowingFunctionWithoutParameters {
     public private(set) var callCount: Int = .zero
 
     /// All the errors that have been thrown by the function.
-    public private(set) var errors: [Error] = []
+    public private(set) var thrownErrors: [Error] = []
 
-    /// The latest error thrown by the function.
-    public var latestError: Error? {
-        self.errors.last
+    /// The last error thrown by the function.
+    public var lastThrownError: Error? {
+        self.thrownErrors.last
     }
 
     // MARK: Initializers
@@ -77,7 +77,7 @@ public final class MockVoidAsyncThrowingFunctionWithoutParameters {
             return
         }
 
-        self.errors.append(error)
+        self.thrownErrors.append(error)
 
         throw error
     }

--- a/Sources/Mocked/MockFunctions/MockVoidFunctions/MockVoidFunctionWithParameters.swift
+++ b/Sources/Mocked/MockFunctions/MockVoidFunctions/MockVoidFunctionWithParameters.swift
@@ -19,8 +19,8 @@ public final class MockVoidFunctionWithParameters<Arguments> {
     /// All the arguments with which the function has been invoked.
     public private(set) var invocations: [Arguments] = []
 
-    /// The latest arguments with which the function has been invoked.
-    public var latestInvocation: Arguments? {
+    /// The last arguments with which the function has been invoked.
+    public var lastInvocation: Arguments? {
         self.invocations.last
     }
 

--- a/Sources/Mocked/MockFunctions/MockVoidFunctions/MockVoidThrowingFunctionWithParameters.swift
+++ b/Sources/Mocked/MockFunctions/MockVoidFunctions/MockVoidThrowingFunctionWithParameters.swift
@@ -22,17 +22,17 @@ public final class MockVoidThrowingFunctionWithParameters<Arguments> {
     /// All the arguments with which the function has been invoked.
     public private(set) var invocations: [Arguments] = []
 
-    /// The latest arguments with which the function has been invoked.
-    public var latestInvocation: Arguments? {
+    /// The last arguments with which the function has been invoked.
+    public var lastInvocation: Arguments? {
         self.invocations.last
     }
 
     /// All the errors that have been thrown by the function.
-    public private(set) var errors: [Error] = []
+    public private(set) var thrownErrors: [Error] = []
 
-    /// The latest error thrown by the function.
-    public var latestError: Error? {
-        self.errors.last
+    /// The last error thrown by the function.
+    public var lastThrownError: Error? {
+        self.thrownErrors.last
     }
 
     // MARK: Initializers
@@ -88,7 +88,7 @@ public final class MockVoidThrowingFunctionWithParameters<Arguments> {
             return
         }
 
-        self.errors.append(error)
+        self.thrownErrors.append(error)
 
         throw error
     }

--- a/Sources/Mocked/MockFunctions/MockVoidFunctions/MockVoidThrowingFunctionWithoutParameters.swift
+++ b/Sources/Mocked/MockFunctions/MockVoidFunctions/MockVoidThrowingFunctionWithoutParameters.swift
@@ -20,11 +20,11 @@ public final class MockVoidThrowingFunctionWithoutParameters {
     public private(set) var callCount: Int = .zero
 
     /// All the errors that have been thrown by the function.
-    public private(set) var errors: [Error] = []
+    public private(set) var thrownErrors: [Error] = []
 
-    /// The latest error thrown by the function.
-    public var latestError: Error? {
-        self.errors.last
+    /// The last error thrown by the function.
+    public var lastThrownError: Error? {
+        self.thrownErrors.last
     }
 
     // MARK: Initializers
@@ -77,7 +77,7 @@ public final class MockVoidThrowingFunctionWithoutParameters {
             return
         }
 
-        self.errors.append(error)
+        self.thrownErrors.append(error)
 
         throw error
     }

--- a/Sources/Mocked/MockVariables/MockAccessors/MockVariableAsyncGetter.swift
+++ b/Sources/Mocked/MockVariables/MockAccessors/MockVariableAsyncGetter.swift
@@ -19,6 +19,14 @@ public final class MockVariableAsyncGetter<Value> {
     /// The number of times the getter has been called.
     public private(set) var callCount: Int = .zero
 
+    /// All the values that have been returned by the getter.
+    public private(set) var returnedValues: [Value] = []
+
+    /// The last value returned by the getter.
+    public var lastReturnedValue: Value? {
+        self.returnedValues.last
+    }
+
     /// The description of the mock's exposed variable.
     ///
     /// This description is used when generating an `unimplemented` test failure
@@ -45,6 +53,10 @@ public final class MockVariableAsyncGetter<Value> {
     func get() async -> Value {
         self.callCount += 1
 
-        return await self.implementation(description: self.exposedVariableDescription)
+        let value = await self.implementation(description: self.exposedVariableDescription)
+
+        self.returnedValues.append(value)
+
+        return value
     }
 }

--- a/Sources/Mocked/MockVariables/MockAccessors/MockVariableAsyncThrowingGetter.swift
+++ b/Sources/Mocked/MockVariables/MockAccessors/MockVariableAsyncThrowingGetter.swift
@@ -19,6 +19,14 @@ public final class MockVariableAsyncThrowingGetter<Value> {
     /// The number of times the getter has been called.
     public private(set) var callCount: Int = .zero
 
+    /// All the values that have been returned by the getter.
+    public private(set) var returnedValues: [Result<Value, Error>] = []
+
+    /// The last value returned by the getter.
+    public var lastReturnedValue: Result<Value, Error>? {
+        self.returnedValues.last
+    }
+
     /// The description of the mock's exposed variable.
     ///
     /// This description is used when generating an `unimplemented` test failure
@@ -45,6 +53,12 @@ public final class MockVariableAsyncThrowingGetter<Value> {
     func get() async throws -> Value {
         self.callCount += 1
 
-        return try await self.implementation(description: self.exposedVariableDescription)
+        let value = await Result {
+            try await self.implementation(description: self.exposedVariableDescription)
+        }
+
+        self.returnedValues.append(value)
+
+        return try value.get()
     }
 }

--- a/Sources/Mocked/MockVariables/MockAccessors/MockVariableGetter.swift
+++ b/Sources/Mocked/MockVariables/MockAccessors/MockVariableGetter.swift
@@ -18,6 +18,14 @@ public final class MockVariableGetter<Value> {
     /// The number of times the getter has been called.
     public private(set) var callCount: Int = .zero
 
+    /// All the values that have been returned by the getter.
+    public private(set) var returnedValues: [Value] = []
+
+    /// The last value returned by the getter.
+    public var lastReturnedValue: Value? {
+        self.returnedValues.last
+    }
+
     /// The description of the mock's exposed variable.
     ///
     /// This description is used when generating an `unimplemented` test failure
@@ -44,6 +52,10 @@ public final class MockVariableGetter<Value> {
     func get() -> Value {
         self.callCount += 1
 
-        return self.implementation(description: self.exposedVariableDescription)
+        let value = self.implementation(description: self.exposedVariableDescription)
+
+        self.returnedValues.append(value)
+
+        return value
     }
 }

--- a/Sources/Mocked/MockVariables/MockAccessors/MockVariableSetter.swift
+++ b/Sources/Mocked/MockVariables/MockAccessors/MockVariableSetter.swift
@@ -16,22 +16,21 @@ public final class MockVariableSetter<Value> {
     public private(set) var callCount: Int = .zero
 
     /// All the values with which the setter has been invoked.
-    public private(set) var values: [Value] = []
+    public private(set) var invocations: [Value] = []
 
-    /// The latest value with which the setter has been invoked.
-    public var latestValue: Value? {
-        self.values.last
+    /// The last value with which the setter has been invoked.
+    public var lastInvocation: Value? {
+        self.invocations.last
     }
 
     // MARK: Set
 
-    /// Records the invocation of the variable's setter and sets the
-    /// variable's value to the provided value.
+    /// Records the invocation of the variable's setter and sets the variable's
+    /// value to the provided value.
     ///
-    /// - Parameter newValue: The value to which to set the variable's
-    ///   value.
+    /// - Parameter newValue: The value to which to set the variable's value.
     func set(_ newValue: Value) {
         self.callCount += 1
-        self.values.append(newValue)
+        self.invocations.append(newValue)
     }
 }

--- a/Sources/Mocked/MockVariables/MockAccessors/MockVariableThrowingGetter.swift
+++ b/Sources/Mocked/MockVariables/MockAccessors/MockVariableThrowingGetter.swift
@@ -19,6 +19,14 @@ public final class MockVariableThrowingGetter<Value> {
     /// The number of times the getter has been called.
     public private(set) var callCount: Int = .zero
 
+    /// All the values that have been returned by the getter.
+    public private(set) var returnedValues: [Result<Value, Error>] = []
+
+    /// The last value returned by the getter.
+    public var lastReturnedValue: Result<Value, Error>? {
+        self.returnedValues.last
+    }
+
     /// The description of the mock's exposed variable.
     ///
     /// This description is used when generating an `unimplemented` test failure
@@ -45,6 +53,12 @@ public final class MockVariableThrowingGetter<Value> {
     func get() throws -> Value {
         self.callCount += 1
 
-        return try self.implementation(description: self.exposedVariableDescription)
+        let value = Result {
+            try self.implementation(description: self.exposedVariableDescription)
+        }
+
+        self.returnedValues.append(value)
+
+        return try value.get()
     }
 }

--- a/Tests/MockedTests/MockFunctions/MockReturningFunctions/MockReturningAsyncFunctionWithParametersTests.swift
+++ b/Tests/MockedTests/MockFunctions/MockReturningFunctions/MockReturningAsyncFunctionWithParametersTests.swift
@@ -62,57 +62,57 @@ final class MockReturningAsyncFunctionWithParametersTests: XCTestCase {
         }
     }
 
-    // MARK: Latest Invocation Tests
+    // MARK: Last Invocation Tests
 
-    func testLatestInvocation() async {
+    func testLastInvocation() async {
         await self.test { sut, invoke in
-            XCTAssertNil(sut.latestInvocation)
+            XCTAssertNil(sut.lastInvocation)
 
             sut.implementation = .returns { 5 }
 
             _ = await invoke(("a", true))
-            XCTAssertEqual(sut.latestInvocation?.string, "a")
-            XCTAssertEqual(sut.latestInvocation?.boolean, true)
+            XCTAssertEqual(sut.lastInvocation?.string, "a")
+            XCTAssertEqual(sut.lastInvocation?.boolean, true)
 
             _ = await invoke(("b", false))
-            XCTAssertEqual(sut.latestInvocation?.string, "b")
-            XCTAssertEqual(sut.latestInvocation?.boolean, false)
+            XCTAssertEqual(sut.lastInvocation?.string, "b")
+            XCTAssertEqual(sut.lastInvocation?.boolean, false)
         }
     }
 
-    // MARK: Return Values Tests
+    // MARK: Returned Values Tests
 
-    func testReturnValues() async {
+    func testReturnedValues() async {
         await self.test { sut, invoke in
-            XCTAssertEqual(sut.returnValues, [])
+            XCTAssertEqual(sut.returnedValues, [])
 
             sut.implementation = .returns { 5 }
 
             _ = await invoke(("a", true))
-            XCTAssertEqual(sut.returnValues, [5])
+            XCTAssertEqual(sut.returnedValues, [5])
 
             sut.implementation = .returns { 10 }
 
             _ = await invoke(("b", false))
-            XCTAssertEqual(sut.returnValues, [5, 10])
+            XCTAssertEqual(sut.returnedValues, [5, 10])
         }
     }
 
-    // MARK: Latest Return Value Tests
+    // MARK: Last Returned Value Tests
 
-    func testLatestReturnValue() async {
+    func testLastReturnedValue() async {
         await self.test { sut, invoke in
-            XCTAssertNil(sut.latestReturnValue)
+            XCTAssertNil(sut.lastReturnedValue)
 
             sut.implementation = .returns { 5 }
 
             _ = await invoke(("a", true))
-            XCTAssertEqual(sut.latestReturnValue, 5)
+            XCTAssertEqual(sut.lastReturnedValue, 5)
 
             sut.implementation = .returns { 10 }
 
             _ = await invoke(("b", false))
-            XCTAssertEqual(sut.latestReturnValue, 10)
+            XCTAssertEqual(sut.lastReturnedValue, 10)
         }
     }
 }

--- a/Tests/MockedTests/MockFunctions/MockReturningFunctions/MockReturningAsyncFunctionWithoutParametersTests.swift
+++ b/Tests/MockedTests/MockFunctions/MockReturningFunctions/MockReturningAsyncFunctionWithoutParametersTests.swift
@@ -39,39 +39,39 @@ final class MockReturningAsyncFunctionWithoutParametersTests: XCTestCase {
         }
     }
 
-    // MARK: Return Values Tests
+    // MARK: Returned Values Tests
 
-    func testReturnValues() async {
+    func testReturnedValues() async {
         await self.test { sut, invoke in
-            XCTAssertEqual(sut.returnValues, [])
+            XCTAssertEqual(sut.returnedValues, [])
 
             sut.implementation = .returns { 5 }
 
             _ = await invoke()
-            XCTAssertEqual(sut.returnValues, [5])
+            XCTAssertEqual(sut.returnedValues, [5])
 
             sut.implementation = .returns { 10 }
 
             _ = await invoke()
-            XCTAssertEqual(sut.returnValues, [5, 10])
+            XCTAssertEqual(sut.returnedValues, [5, 10])
         }
     }
 
-    // MARK: Latest Return Value Tests
+    // MARK: Last Returned Value Tests
 
-    func testLatestReturnValue() async {
+    func testLastReturnedValue() async {
         await self.test { sut, invoke in
-            XCTAssertNil(sut.latestReturnValue)
+            XCTAssertNil(sut.lastReturnedValue)
 
             sut.implementation = .returns { 5 }
 
             _ = await invoke()
-            XCTAssertEqual(sut.latestReturnValue, 5)
+            XCTAssertEqual(sut.lastReturnedValue, 5)
 
             sut.implementation = .returns { 10 }
 
             _ = await invoke()
-            XCTAssertEqual(sut.latestReturnValue, 10)
+            XCTAssertEqual(sut.lastReturnedValue, 10)
         }
     }
 }

--- a/Tests/MockedTests/MockFunctions/MockReturningFunctions/MockReturningAsyncThrowingFunctionWithParametersTests.swift
+++ b/Tests/MockedTests/MockFunctions/MockReturningFunctions/MockReturningAsyncThrowingFunctionWithParametersTests.swift
@@ -84,17 +84,17 @@ final class MockReturningAsyncThrowingFunctionWithParametersTests: XCTestCase {
         }
     }
 
-    // MARK: Return Values Tests
+    // MARK: Returned Values Tests
 
-    func testReturnValues() async throws {
+    func testReturnedValues() async throws {
         try await self.test { sut, invoke in
-            XCTAssertTrue(sut.returnValues.isEmpty)
+            XCTAssertTrue(sut.returnedValues.isEmpty)
 
             sut.implementation = .returns { 5 }
 
             _ = try await invoke(("a", true))
-            XCTAssertEqual(sut.returnValues.count, 1)
-            XCTAssertEqual(try sut.returnValues.first?.get(), 5)
+            XCTAssertEqual(sut.returnedValues.count, 1)
+            XCTAssertEqual(try sut.returnedValues.first?.get(), 5)
 
             sut.implementation = .throws { URLError(.badURL) }
 
@@ -103,11 +103,11 @@ final class MockReturningAsyncThrowingFunctionWithParametersTests: XCTestCase {
                 XCTFail("Expected invoke to throw an error")
             } catch let error as URLError {
                 XCTAssertEqual(error.code, .badURL)
-                XCTAssertEqual(sut.returnValues.count, 2)
-                XCTAssertEqual(try sut.returnValues.first?.get(), 5)
+                XCTAssertEqual(sut.returnedValues.count, 2)
+                XCTAssertEqual(try sut.returnedValues.first?.get(), 5)
 
                 do {
-                    _ = try sut.returnValues.last?.get()
+                    _ = try sut.returnedValues.last?.get()
                     XCTFail("Expected last return value to throw an error")
                 } catch let error as URLError {
                     XCTAssertEqual(error.code, .badURL)
@@ -120,16 +120,16 @@ final class MockReturningAsyncThrowingFunctionWithParametersTests: XCTestCase {
         }
     }
 
-    // MARK: Latest Return Value Tests
+    // MARK: Last Returned Value Tests
 
-    func testLatestReturnValue() async throws {
+    func testLastReturnedValue() async throws {
         try await self.test { sut, invoke in
-            XCTAssertNil(sut.latestReturnValue)
+            XCTAssertNil(sut.lastReturnedValue)
 
             sut.implementation = .returns { 5 }
 
             _ = try await invoke(("a", true))
-            XCTAssertEqual(try sut.latestReturnValue?.get(), 5)
+            XCTAssertEqual(try sut.lastReturnedValue?.get(), 5)
 
             sut.implementation = .throws { URLError(.badURL) }
 
@@ -140,8 +140,8 @@ final class MockReturningAsyncThrowingFunctionWithParametersTests: XCTestCase {
                 XCTAssertEqual(error.code, .badURL)
 
                 do {
-                    _ = try sut.latestReturnValue?.get()
-                    XCTFail("Expected latest return value to throw an error")
+                    _ = try sut.lastReturnedValue?.get()
+                    XCTFail("Expected last return value to throw an error")
                 } catch let error as URLError {
                     XCTAssertEqual(error.code, .badURL)
                 } catch {

--- a/Tests/MockedTests/MockFunctions/MockReturningFunctions/MockReturningAsyncThrowingFunctionWithoutParametersTests.swift
+++ b/Tests/MockedTests/MockFunctions/MockReturningFunctions/MockReturningAsyncThrowingFunctionWithoutParametersTests.swift
@@ -52,17 +52,17 @@ final class MockReturningAsyncThrowingFunctionWithoutParametersTests: XCTestCase
         }
     }
 
-    // MARK: Return Values Tests
+    // MARK: Returned Values Tests
 
-    func testReturnValues() async throws {
+    func testReturnedValues() async throws {
         try await self.test { sut, invoke in
-            XCTAssertTrue(sut.returnValues.isEmpty)
+            XCTAssertTrue(sut.returnedValues.isEmpty)
 
             sut.implementation = .returns { 5 }
 
             _ = try await invoke()
-            XCTAssertEqual(sut.returnValues.count, 1)
-            XCTAssertEqual(try sut.returnValues.first?.get(), 5)
+            XCTAssertEqual(sut.returnedValues.count, 1)
+            XCTAssertEqual(try sut.returnedValues.first?.get(), 5)
 
             sut.implementation = .throws { URLError(.badURL) }
 
@@ -71,11 +71,11 @@ final class MockReturningAsyncThrowingFunctionWithoutParametersTests: XCTestCase
                 XCTFail("Expected invoke to throw an error")
             } catch let error as URLError {
                 XCTAssertEqual(error.code, .badURL)
-                XCTAssertEqual(sut.returnValues.count, 2)
-                XCTAssertEqual(try sut.returnValues.first?.get(), 5)
+                XCTAssertEqual(sut.returnedValues.count, 2)
+                XCTAssertEqual(try sut.returnedValues.first?.get(), 5)
 
                 do {
-                    _ = try sut.returnValues.last?.get()
+                    _ = try sut.returnedValues.last?.get()
                     XCTFail("Expected last return value to throw an error")
                 } catch let error as URLError {
                     XCTAssertEqual(error.code, .badURL)
@@ -88,16 +88,16 @@ final class MockReturningAsyncThrowingFunctionWithoutParametersTests: XCTestCase
         }
     }
 
-    // MARK: Latest Return Value Tests
+    // MARK: Last Returned Value Tests
 
-    func testLatestReturnValue() async throws {
+    func testLastReturnedValue() async throws {
         try await self.test { sut, invoke in
-            XCTAssertNil(sut.latestReturnValue)
+            XCTAssertNil(sut.lastReturnedValue)
 
             sut.implementation = .returns { 5 }
 
             _ = try await invoke()
-            XCTAssertEqual(try sut.latestReturnValue?.get(), 5)
+            XCTAssertEqual(try sut.lastReturnedValue?.get(), 5)
 
             sut.implementation = .throws { URLError(.badURL) }
 
@@ -108,8 +108,8 @@ final class MockReturningAsyncThrowingFunctionWithoutParametersTests: XCTestCase
                 XCTAssertEqual(error.code, .badURL)
 
                 do {
-                    _ = try sut.latestReturnValue?.get()
-                    XCTFail("Expected latest return value to throw an error")
+                    _ = try sut.lastReturnedValue?.get()
+                    XCTFail("Expected last return value to throw an error")
                 } catch let error as URLError {
                     XCTAssertEqual(error.code, .badURL)
                 } catch {

--- a/Tests/MockedTests/MockFunctions/MockReturningFunctions/MockReturningFunctionWithParametersTests.swift
+++ b/Tests/MockedTests/MockFunctions/MockReturningFunctions/MockReturningFunctionWithParametersTests.swift
@@ -62,57 +62,57 @@ final class MockReturningFunctionWithParametersTests: XCTestCase {
         }
     }
 
-    // MARK: Latest Invocation Tests
+    // MARK: Last Invocation Tests
 
-    func testLatestInvocation() {
+    func testLastInvocation() {
         self.test { sut, invoke in
-            XCTAssertNil(sut.latestInvocation)
+            XCTAssertNil(sut.lastInvocation)
 
             sut.implementation = .returns(5)
 
             _ = invoke(("a", true))
-            XCTAssertEqual(sut.latestInvocation?.string, "a")
-            XCTAssertEqual(sut.latestInvocation?.boolean, true)
+            XCTAssertEqual(sut.lastInvocation?.string, "a")
+            XCTAssertEqual(sut.lastInvocation?.boolean, true)
 
             _ = invoke(("b", false))
-            XCTAssertEqual(sut.latestInvocation?.string, "b")
-            XCTAssertEqual(sut.latestInvocation?.boolean, false)
+            XCTAssertEqual(sut.lastInvocation?.string, "b")
+            XCTAssertEqual(sut.lastInvocation?.boolean, false)
         }
     }
 
-    // MARK: Return Values Tests
+    // MARK: Returned Values Tests
 
-    func testReturnValues() {
+    func testReturnedValues() {
         self.test { sut, invoke in
-            XCTAssertEqual(sut.returnValues, [])
+            XCTAssertEqual(sut.returnedValues, [])
 
             sut.implementation = .returns(5)
 
             _ = invoke(("a", true))
-            XCTAssertEqual(sut.returnValues, [5])
+            XCTAssertEqual(sut.returnedValues, [5])
 
             sut.implementation = .returns(10)
 
             _ = invoke(("b", false))
-            XCTAssertEqual(sut.returnValues, [5, 10])
+            XCTAssertEqual(sut.returnedValues, [5, 10])
         }
     }
 
-    // MARK: Latest Return Value Tests
+    // MARK: Last Returned Value Tests
 
-    func testLatestReturnValue() {
+    func testLastReturnedValue() {
         self.test { sut, invoke in
-            XCTAssertNil(sut.latestReturnValue)
+            XCTAssertNil(sut.lastReturnedValue)
 
             sut.implementation = .returns(5)
 
             _ = invoke(("a", true))
-            XCTAssertEqual(sut.latestReturnValue, 5)
+            XCTAssertEqual(sut.lastReturnedValue, 5)
 
             sut.implementation = .returns(10)
 
             _ = invoke(("b", false))
-            XCTAssertEqual(sut.latestReturnValue, 10)
+            XCTAssertEqual(sut.lastReturnedValue, 10)
         }
     }
 }

--- a/Tests/MockedTests/MockFunctions/MockReturningFunctions/MockReturningFunctionWithoutParametersTests.swift
+++ b/Tests/MockedTests/MockFunctions/MockReturningFunctions/MockReturningFunctionWithoutParametersTests.swift
@@ -39,39 +39,39 @@ final class MockReturningFunctionWithoutParametersTests: XCTestCase {
         }
     }
 
-    // MARK: Return Values Tests
+    // MARK: Returned Values Tests
 
-    func testReturnValues() {
+    func testReturnedValues() {
         self.test { sut, invoke in
-            XCTAssertEqual(sut.returnValues, [])
+            XCTAssertEqual(sut.returnedValues, [])
 
             sut.implementation = .returns(5)
 
             _ = invoke()
-            XCTAssertEqual(sut.returnValues, [5])
+            XCTAssertEqual(sut.returnedValues, [5])
 
             sut.implementation = .returns(10)
 
             _ = invoke()
-            XCTAssertEqual(sut.returnValues, [5, 10])
+            XCTAssertEqual(sut.returnedValues, [5, 10])
         }
     }
 
-    // MARK: Latest Return Value Tests
+    // MARK: Last Returned Value Tests
 
-    func testLatestReturnValue() {
+    func testLastReturnedValue() {
         self.test { sut, invoke in
-            XCTAssertNil(sut.latestReturnValue)
+            XCTAssertNil(sut.lastReturnedValue)
 
             sut.implementation = .returns(5)
 
             _ = invoke()
-            XCTAssertEqual(sut.latestReturnValue, 5)
+            XCTAssertEqual(sut.lastReturnedValue, 5)
 
             sut.implementation = .returns(10)
 
             _ = invoke()
-            XCTAssertEqual(sut.latestReturnValue, 10)
+            XCTAssertEqual(sut.lastReturnedValue, 10)
         }
     }
 }

--- a/Tests/MockedTests/MockFunctions/MockReturningFunctions/MockReturningThrowingFunctionWithParametersTests.swift
+++ b/Tests/MockedTests/MockFunctions/MockReturningFunctions/MockReturningThrowingFunctionWithParametersTests.swift
@@ -84,17 +84,17 @@ final class MockReturningThrowingFunctionWithParametersTests: XCTestCase {
         }
     }
 
-    // MARK: Return Values Tests
+    // MARK: Returned Values Tests
 
-    func testReturnValues() throws {
+    func testReturnedValues() throws {
         try self.test { sut, invoke in
-            XCTAssertTrue(sut.returnValues.isEmpty)
+            XCTAssertTrue(sut.returnedValues.isEmpty)
 
             sut.implementation = .returns(5)
 
             _ = try invoke(("a", true))
-            XCTAssertEqual(sut.returnValues.count, 1)
-            XCTAssertEqual(try sut.returnValues.first?.get(), 5)
+            XCTAssertEqual(sut.returnedValues.count, 1)
+            XCTAssertEqual(try sut.returnedValues.first?.get(), 5)
 
             sut.implementation = .throws(URLError(.badURL))
 
@@ -103,11 +103,11 @@ final class MockReturningThrowingFunctionWithParametersTests: XCTestCase {
                 XCTFail("Expected invoke to throw an error")
             } catch let error as URLError {
                 XCTAssertEqual(error.code, .badURL)
-                XCTAssertEqual(sut.returnValues.count, 2)
-                XCTAssertEqual(try sut.returnValues.first?.get(), 5)
+                XCTAssertEqual(sut.returnedValues.count, 2)
+                XCTAssertEqual(try sut.returnedValues.first?.get(), 5)
 
                 do {
-                    _ = try sut.returnValues.last?.get()
+                    _ = try sut.returnedValues.last?.get()
                     XCTFail("Expected last return value to throw an error")
                 } catch let error as URLError {
                     XCTAssertEqual(error.code, .badURL)
@@ -120,16 +120,16 @@ final class MockReturningThrowingFunctionWithParametersTests: XCTestCase {
         }
     }
 
-    // MARK: Latest Return Value Tests
+    // MARK: Last Returned Value Tests
 
-    func testLatestReturnValue() throws {
+    func testLastReturnedValue() throws {
         try self.test { sut, invoke in
-            XCTAssertNil(sut.latestReturnValue)
+            XCTAssertNil(sut.lastReturnedValue)
 
             sut.implementation = .returns(5)
 
             _ = try invoke(("a", true))
-            XCTAssertEqual(try sut.latestReturnValue?.get(), 5)
+            XCTAssertEqual(try sut.lastReturnedValue?.get(), 5)
 
             sut.implementation = .throws(URLError(.badURL))
 
@@ -140,8 +140,8 @@ final class MockReturningThrowingFunctionWithParametersTests: XCTestCase {
                 XCTAssertEqual(error.code, .badURL)
 
                 do {
-                    _ = try sut.latestReturnValue?.get()
-                    XCTFail("Expected latest return value to throw an error")
+                    _ = try sut.lastReturnedValue?.get()
+                    XCTFail("Expected last return value to throw an error")
                 } catch let error as URLError {
                     XCTAssertEqual(error.code, .badURL)
                 } catch {

--- a/Tests/MockedTests/MockFunctions/MockReturningFunctions/MockReturningThrowingFunctionWithoutParametersTests.swift
+++ b/Tests/MockedTests/MockFunctions/MockReturningFunctions/MockReturningThrowingFunctionWithoutParametersTests.swift
@@ -52,17 +52,17 @@ final class MockReturningThrowingFunctionWithoutParametersTests: XCTestCase {
         }
     }
 
-    // MARK: Return Values Tests
+    // MARK: Returned Values Tests
 
-    func testReturnValues() throws {
+    func testReturnedValues() throws {
         try self.test { sut, invoke in
-            XCTAssertTrue(sut.returnValues.isEmpty)
+            XCTAssertTrue(sut.returnedValues.isEmpty)
 
             sut.implementation = .returns(5)
 
             _ = try invoke()
-            XCTAssertEqual(sut.returnValues.count, 1)
-            XCTAssertEqual(try sut.returnValues.first?.get(), 5)
+            XCTAssertEqual(sut.returnedValues.count, 1)
+            XCTAssertEqual(try sut.returnedValues.first?.get(), 5)
 
             sut.implementation = .throws(URLError(.badURL))
 
@@ -71,11 +71,11 @@ final class MockReturningThrowingFunctionWithoutParametersTests: XCTestCase {
                 XCTFail("Expected invoke to throw an error")
             } catch let error as URLError {
                 XCTAssertEqual(error.code, .badURL)
-                XCTAssertEqual(sut.returnValues.count, 2)
-                XCTAssertEqual(try sut.returnValues.first?.get(), 5)
+                XCTAssertEqual(sut.returnedValues.count, 2)
+                XCTAssertEqual(try sut.returnedValues.first?.get(), 5)
 
                 do {
-                    _ = try sut.returnValues.last?.get()
+                    _ = try sut.returnedValues.last?.get()
                     XCTFail("Expected last return value to throw an error")
                 } catch let error as URLError {
                     XCTAssertEqual(error.code, .badURL)
@@ -88,16 +88,16 @@ final class MockReturningThrowingFunctionWithoutParametersTests: XCTestCase {
         }
     }
 
-    // MARK: Latest Return Value Tests
+    // MARK: Last Returned Value Tests
 
-    func testLatestReturnValue() throws {
+    func testLastReturnedValue() throws {
         try self.test { sut, invoke in
-            XCTAssertNil(sut.latestReturnValue)
+            XCTAssertNil(sut.lastReturnedValue)
 
             sut.implementation = .returns(5)
 
             _ = try invoke()
-            XCTAssertEqual(try sut.latestReturnValue?.get(), 5)
+            XCTAssertEqual(try sut.lastReturnedValue?.get(), 5)
 
             sut.implementation = .throws(URLError(.badURL))
 
@@ -108,8 +108,8 @@ final class MockReturningThrowingFunctionWithoutParametersTests: XCTestCase {
                 XCTAssertEqual(error.code, .badURL)
 
                 do {
-                    _ = try sut.latestReturnValue?.get()
-                    XCTFail("Expected latest return value to throw an error")
+                    _ = try sut.lastReturnedValue?.get()
+                    XCTFail("Expected last return value to throw an error")
                 } catch let error as URLError {
                     XCTAssertEqual(error.code, .badURL)
                 } catch {

--- a/Tests/MockedTests/MockFunctions/MockVoidFunctions/MockVoidAsyncFunctionWithParametersTests.swift
+++ b/Tests/MockedTests/MockFunctions/MockVoidFunctions/MockVoidAsyncFunctionWithParametersTests.swift
@@ -46,19 +46,19 @@ final class MockVoidAsyncFunctionWithParametersTests: XCTestCase {
         }
     }
 
-    // MARK: Latest Invocation Tests
+    // MARK: Last Invocation Tests
 
-    func testLatestInvocation() async {
+    func testLastInvocation() async {
         await self.test { sut, invoke in
-            XCTAssertNil(sut.latestInvocation)
+            XCTAssertNil(sut.lastInvocation)
 
             _ = await invoke(("a", true))
-            XCTAssertEqual(sut.latestInvocation?.string, "a")
-            XCTAssertEqual(sut.latestInvocation?.boolean, true)
+            XCTAssertEqual(sut.lastInvocation?.string, "a")
+            XCTAssertEqual(sut.lastInvocation?.boolean, true)
 
             _ = await invoke(("b", false))
-            XCTAssertEqual(sut.latestInvocation?.string, "b")
-            XCTAssertEqual(sut.latestInvocation?.boolean, false)
+            XCTAssertEqual(sut.lastInvocation?.string, "b")
+            XCTAssertEqual(sut.lastInvocation?.boolean, false)
         }
     }
 }

--- a/Tests/MockedTests/MockFunctions/MockVoidFunctions/MockVoidAsyncThrowingFunctionWithParametersTests.swift
+++ b/Tests/MockedTests/MockFunctions/MockVoidFunctions/MockVoidAsyncThrowingFunctionWithParametersTests.swift
@@ -59,19 +59,19 @@ final class MockVoidAsyncThrowingFunctionWithParametersTests: XCTestCase {
         }
     }
 
-    // MARK: Latest Invocation Tests
+    // MARK: Last Invocation Tests
 
-    func testLatestInvocation() async throws {
+    func testLastInvocation() async throws {
         try await self.test { sut, invoke in
-            XCTAssertNil(sut.latestInvocation)
+            XCTAssertNil(sut.lastInvocation)
 
             _ = try await invoke(("a", true))
-            XCTAssertEqual(sut.latestInvocation?.string, "a")
-            XCTAssertEqual(sut.latestInvocation?.boolean, true)
+            XCTAssertEqual(sut.lastInvocation?.string, "a")
+            XCTAssertEqual(sut.lastInvocation?.boolean, true)
 
             _ = try await invoke(("b", false))
-            XCTAssertEqual(sut.latestInvocation?.string, "b")
-            XCTAssertEqual(sut.latestInvocation?.boolean, false)
+            XCTAssertEqual(sut.lastInvocation?.string, "b")
+            XCTAssertEqual(sut.lastInvocation?.boolean, false)
         }
     }
 
@@ -79,10 +79,10 @@ final class MockVoidAsyncThrowingFunctionWithParametersTests: XCTestCase {
 
     func testErrors() async throws {
         try await self.test { sut, invoke in
-            XCTAssertTrue(sut.errors.isEmpty)
+            XCTAssertTrue(sut.thrownErrors.isEmpty)
 
             _ = try await invoke(("a", true))
-            XCTAssertTrue(sut.errors.isEmpty)
+            XCTAssertTrue(sut.thrownErrors.isEmpty)
 
             sut.error = URLError(.badURL)
 
@@ -91,9 +91,9 @@ final class MockVoidAsyncThrowingFunctionWithParametersTests: XCTestCase {
                 XCTFail("Expected invoke to throw an error")
             } catch let error as URLError {
                 XCTAssertEqual(error.code, .badURL)
-                XCTAssertEqual(sut.errors.count, 1)
+                XCTAssertEqual(sut.thrownErrors.count, 1)
 
-                let firstError = try XCTUnwrap(sut.errors.first as? URLError)
+                let firstError = try XCTUnwrap(sut.thrownErrors.first as? URLError)
 
                 XCTAssertEqual(firstError.code, .badURL)
             } catch {
@@ -107,10 +107,10 @@ final class MockVoidAsyncThrowingFunctionWithParametersTests: XCTestCase {
                 XCTFail("Expected invoke to throw an error")
             } catch let error as URLError {
                 XCTAssertEqual(error.code, .badServerResponse)
-                XCTAssertEqual(sut.errors.count, 2)
+                XCTAssertEqual(sut.thrownErrors.count, 2)
 
-                let firstError = try XCTUnwrap(sut.errors.first as? URLError)
-                let lastError = try XCTUnwrap(sut.errors.last as? URLError)
+                let firstError = try XCTUnwrap(sut.thrownErrors.first as? URLError)
+                let lastError = try XCTUnwrap(sut.thrownErrors.last as? URLError)
 
                 XCTAssertEqual(firstError.code, .badURL)
                 XCTAssertEqual(lastError.code, .badServerResponse)
@@ -120,14 +120,14 @@ final class MockVoidAsyncThrowingFunctionWithParametersTests: XCTestCase {
         }
     }
 
-    // MARK: Latest Error Tests
+    // MARK: Last Error Tests
 
-    func testLatestError() async throws {
+    func testLastError() async throws {
         try await self.test { sut, invoke in
-            XCTAssertNil(sut.latestError)
+            XCTAssertNil(sut.lastThrownError)
 
             _ = try await invoke(("a", true))
-            XCTAssertNil(sut.latestError)
+            XCTAssertNil(sut.lastThrownError)
 
             sut.error = URLError(.badURL)
 
@@ -137,9 +137,9 @@ final class MockVoidAsyncThrowingFunctionWithParametersTests: XCTestCase {
             } catch let error as URLError {
                 XCTAssertEqual(error.code, .badURL)
 
-                let latestError = try XCTUnwrap(sut.latestError as? URLError)
+                let lastError = try XCTUnwrap(sut.lastThrownError as? URLError)
 
-                XCTAssertEqual(latestError.code, .badURL)
+                XCTAssertEqual(lastError.code, .badURL)
             } catch {
                 XCTFail("Expected \(error) to equal URLError(.badURL)")
             }
@@ -152,9 +152,9 @@ final class MockVoidAsyncThrowingFunctionWithParametersTests: XCTestCase {
             } catch let error as URLError {
                 XCTAssertEqual(error.code, .badServerResponse)
 
-                let latestError = try XCTUnwrap(sut.latestError as? URLError)
+                let lastError = try XCTUnwrap(sut.lastThrownError as? URLError)
 
-                XCTAssertEqual(latestError.code, .badServerResponse)
+                XCTAssertEqual(lastError.code, .badServerResponse)
             } catch {
                 XCTFail("Expected \(error) to equal URLError(.badServerResponse)")
             }

--- a/Tests/MockedTests/MockFunctions/MockVoidFunctions/MockVoidAsyncThrowingFunctionWithoutParametersTests.swift
+++ b/Tests/MockedTests/MockFunctions/MockVoidFunctions/MockVoidAsyncThrowingFunctionWithoutParametersTests.swift
@@ -42,10 +42,10 @@ final class MockVoidAsyncThrowingFunctionWithoutParametersTests: XCTestCase {
 
     func testErrors() async throws {
         try await self.test { sut, invoke in
-            XCTAssertTrue(sut.errors.isEmpty)
+            XCTAssertTrue(sut.thrownErrors.isEmpty)
 
             _ = try await invoke()
-            XCTAssertTrue(sut.errors.isEmpty)
+            XCTAssertTrue(sut.thrownErrors.isEmpty)
 
             sut.error = URLError(.badURL)
 
@@ -54,9 +54,9 @@ final class MockVoidAsyncThrowingFunctionWithoutParametersTests: XCTestCase {
                 XCTFail("Expected invoke to throw an error")
             } catch let error as URLError {
                 XCTAssertEqual(error.code, .badURL)
-                XCTAssertEqual(sut.errors.count, 1)
+                XCTAssertEqual(sut.thrownErrors.count, 1)
 
-                let firstError = try XCTUnwrap(sut.errors.first as? URLError)
+                let firstError = try XCTUnwrap(sut.thrownErrors.first as? URLError)
 
                 XCTAssertEqual(firstError.code, .badURL)
             } catch {
@@ -70,10 +70,10 @@ final class MockVoidAsyncThrowingFunctionWithoutParametersTests: XCTestCase {
                 XCTFail("Expected invoke to throw an error")
             } catch let error as URLError {
                 XCTAssertEqual(error.code, .badServerResponse)
-                XCTAssertEqual(sut.errors.count, 2)
+                XCTAssertEqual(sut.thrownErrors.count, 2)
 
-                let firstError = try XCTUnwrap(sut.errors.first as? URLError)
-                let lastError = try XCTUnwrap(sut.errors.last as? URLError)
+                let firstError = try XCTUnwrap(sut.thrownErrors.first as? URLError)
+                let lastError = try XCTUnwrap(sut.thrownErrors.last as? URLError)
 
                 XCTAssertEqual(firstError.code, .badURL)
                 XCTAssertEqual(lastError.code, .badServerResponse)
@@ -83,14 +83,14 @@ final class MockVoidAsyncThrowingFunctionWithoutParametersTests: XCTestCase {
         }
     }
 
-    // MARK: Latest Error Tests
+    // MARK: Last Error Tests
 
-    func testLatestError() async throws {
+    func testLastError() async throws {
         try await self.test { sut, invoke in
-            XCTAssertNil(sut.latestError)
+            XCTAssertNil(sut.lastThrownError)
 
             _ = try await invoke()
-            XCTAssertNil(sut.latestError)
+            XCTAssertNil(sut.lastThrownError)
 
             sut.error = URLError(.badURL)
 
@@ -100,9 +100,9 @@ final class MockVoidAsyncThrowingFunctionWithoutParametersTests: XCTestCase {
             } catch let error as URLError {
                 XCTAssertEqual(error.code, .badURL)
 
-                let latestError = try XCTUnwrap(sut.latestError as? URLError)
+                let lastError = try XCTUnwrap(sut.lastThrownError as? URLError)
 
-                XCTAssertEqual(latestError.code, .badURL)
+                XCTAssertEqual(lastError.code, .badURL)
             } catch {
                 XCTFail("Expected \(error) to equal URLError(.badURL)")
             }
@@ -115,9 +115,9 @@ final class MockVoidAsyncThrowingFunctionWithoutParametersTests: XCTestCase {
             } catch let error as URLError {
                 XCTAssertEqual(error.code, .badServerResponse)
 
-                let latestError = try XCTUnwrap(sut.latestError as? URLError)
+                let lastError = try XCTUnwrap(sut.lastThrownError as? URLError)
 
-                XCTAssertEqual(latestError.code, .badServerResponse)
+                XCTAssertEqual(lastError.code, .badServerResponse)
             } catch {
                 XCTFail("Expected \(error) to equal URLError(.badServerResponse)")
             }

--- a/Tests/MockedTests/MockFunctions/MockVoidFunctions/MockVoidFunctionWithParametersTests.swift
+++ b/Tests/MockedTests/MockFunctions/MockVoidFunctions/MockVoidFunctionWithParametersTests.swift
@@ -46,19 +46,19 @@ final class MockVoidFunctionWithParametersTests: XCTestCase {
         }
     }
 
-    // MARK: Latest Invocation Tests
+    // MARK: Last Invocation Tests
 
-    func testLatestInvocation() {
+    func testLastInvocation() {
         self.test { sut, invoke in
-            XCTAssertNil(sut.latestInvocation)
+            XCTAssertNil(sut.lastInvocation)
 
             _ = invoke(("a", true))
-            XCTAssertEqual(sut.latestInvocation?.string, "a")
-            XCTAssertEqual(sut.latestInvocation?.boolean, true)
+            XCTAssertEqual(sut.lastInvocation?.string, "a")
+            XCTAssertEqual(sut.lastInvocation?.boolean, true)
 
             _ = invoke(("b", false))
-            XCTAssertEqual(sut.latestInvocation?.string, "b")
-            XCTAssertEqual(sut.latestInvocation?.boolean, false)
+            XCTAssertEqual(sut.lastInvocation?.string, "b")
+            XCTAssertEqual(sut.lastInvocation?.boolean, false)
         }
     }
 }

--- a/Tests/MockedTests/MockFunctions/MockVoidFunctions/MockVoidThrowingFunctionWithParametersTests.swift
+++ b/Tests/MockedTests/MockFunctions/MockVoidFunctions/MockVoidThrowingFunctionWithParametersTests.swift
@@ -59,19 +59,19 @@ final class MockVoidThrowingFunctionWithParametersTests: XCTestCase {
         }
     }
 
-    // MARK: Latest Invocation Tests
+    // MARK: Last Invocation Tests
 
-    func testLatestInvocation() throws {
+    func testLastInvocation() throws {
         try self.test { sut, invoke in
-            XCTAssertNil(sut.latestInvocation)
+            XCTAssertNil(sut.lastInvocation)
 
             _ = try invoke(("a", true))
-            XCTAssertEqual(sut.latestInvocation?.string, "a")
-            XCTAssertEqual(sut.latestInvocation?.boolean, true)
+            XCTAssertEqual(sut.lastInvocation?.string, "a")
+            XCTAssertEqual(sut.lastInvocation?.boolean, true)
 
             _ = try invoke(("b", false))
-            XCTAssertEqual(sut.latestInvocation?.string, "b")
-            XCTAssertEqual(sut.latestInvocation?.boolean, false)
+            XCTAssertEqual(sut.lastInvocation?.string, "b")
+            XCTAssertEqual(sut.lastInvocation?.boolean, false)
         }
     }
 
@@ -79,10 +79,10 @@ final class MockVoidThrowingFunctionWithParametersTests: XCTestCase {
 
     func testErrors() throws {
         try self.test { sut, invoke in
-            XCTAssertTrue(sut.errors.isEmpty)
+            XCTAssertTrue(sut.thrownErrors.isEmpty)
 
             _ = try invoke(("a", true))
-            XCTAssertTrue(sut.errors.isEmpty)
+            XCTAssertTrue(sut.thrownErrors.isEmpty)
 
             sut.error = URLError(.badURL)
 
@@ -91,9 +91,9 @@ final class MockVoidThrowingFunctionWithParametersTests: XCTestCase {
                 XCTFail("Expected invoke to throw an error")
             } catch let error as URLError {
                 XCTAssertEqual(error.code, .badURL)
-                XCTAssertEqual(sut.errors.count, 1)
+                XCTAssertEqual(sut.thrownErrors.count, 1)
 
-                let firstError = try XCTUnwrap(sut.errors.first as? URLError)
+                let firstError = try XCTUnwrap(sut.thrownErrors.first as? URLError)
 
                 XCTAssertEqual(firstError.code, .badURL)
             } catch {
@@ -107,10 +107,10 @@ final class MockVoidThrowingFunctionWithParametersTests: XCTestCase {
                 XCTFail("Expected invoke to throw an error")
             } catch let error as URLError {
                 XCTAssertEqual(error.code, .badServerResponse)
-                XCTAssertEqual(sut.errors.count, 2)
+                XCTAssertEqual(sut.thrownErrors.count, 2)
 
-                let firstError = try XCTUnwrap(sut.errors.first as? URLError)
-                let lastError = try XCTUnwrap(sut.errors.last as? URLError)
+                let firstError = try XCTUnwrap(sut.thrownErrors.first as? URLError)
+                let lastError = try XCTUnwrap(sut.thrownErrors.last as? URLError)
 
                 XCTAssertEqual(firstError.code, .badURL)
                 XCTAssertEqual(lastError.code, .badServerResponse)
@@ -120,14 +120,14 @@ final class MockVoidThrowingFunctionWithParametersTests: XCTestCase {
         }
     }
 
-    // MARK: Latest Error Tests
+    // MARK: Last Error Tests
 
-    func testLatestError() throws {
+    func testLastError() throws {
         try self.test { sut, invoke in
-            XCTAssertNil(sut.latestError)
+            XCTAssertNil(sut.lastThrownError)
 
             _ = try invoke(("a", true))
-            XCTAssertNil(sut.latestError)
+            XCTAssertNil(sut.lastThrownError)
 
             sut.error = URLError(.badURL)
 
@@ -137,9 +137,9 @@ final class MockVoidThrowingFunctionWithParametersTests: XCTestCase {
             } catch let error as URLError {
                 XCTAssertEqual(error.code, .badURL)
 
-                let latestError = try XCTUnwrap(sut.latestError as? URLError)
+                let lastError = try XCTUnwrap(sut.lastThrownError as? URLError)
 
-                XCTAssertEqual(latestError.code, .badURL)
+                XCTAssertEqual(lastError.code, .badURL)
             } catch {
                 XCTFail("Expected \(error) to equal URLError(.badURL)")
             }
@@ -152,9 +152,9 @@ final class MockVoidThrowingFunctionWithParametersTests: XCTestCase {
             } catch let error as URLError {
                 XCTAssertEqual(error.code, .badServerResponse)
 
-                let latestError = try XCTUnwrap(sut.latestError as? URLError)
+                let lastError = try XCTUnwrap(sut.lastThrownError as? URLError)
 
-                XCTAssertEqual(latestError.code, .badServerResponse)
+                XCTAssertEqual(lastError.code, .badServerResponse)
             } catch {
                 XCTFail("Expected \(error) to equal URLError(.badServerResponse)")
             }

--- a/Tests/MockedTests/MockFunctions/MockVoidFunctions/MockVoidThrowingFunctionWithoutParametersTests.swift
+++ b/Tests/MockedTests/MockFunctions/MockVoidFunctions/MockVoidThrowingFunctionWithoutParametersTests.swift
@@ -42,10 +42,10 @@ final class MockVoidThrowingFunctionWithoutParametersTests: XCTestCase {
 
     func testErrors() throws {
         try self.test { sut, invoke in
-            XCTAssertTrue(sut.errors.isEmpty)
+            XCTAssertTrue(sut.thrownErrors.isEmpty)
 
             _ = try invoke()
-            XCTAssertTrue(sut.errors.isEmpty)
+            XCTAssertTrue(sut.thrownErrors.isEmpty)
 
             sut.error = URLError(.badURL)
 
@@ -54,9 +54,9 @@ final class MockVoidThrowingFunctionWithoutParametersTests: XCTestCase {
                 XCTFail("Expected invoke to throw an error")
             } catch let error as URLError {
                 XCTAssertEqual(error.code, .badURL)
-                XCTAssertEqual(sut.errors.count, 1)
+                XCTAssertEqual(sut.thrownErrors.count, 1)
 
-                let firstError = try XCTUnwrap(sut.errors.first as? URLError)
+                let firstError = try XCTUnwrap(sut.thrownErrors.first as? URLError)
 
                 XCTAssertEqual(firstError.code, .badURL)
             } catch {
@@ -70,10 +70,10 @@ final class MockVoidThrowingFunctionWithoutParametersTests: XCTestCase {
                 XCTFail("Expected invoke to throw an error")
             } catch let error as URLError {
                 XCTAssertEqual(error.code, .badServerResponse)
-                XCTAssertEqual(sut.errors.count, 2)
+                XCTAssertEqual(sut.thrownErrors.count, 2)
 
-                let firstError = try XCTUnwrap(sut.errors.first as? URLError)
-                let lastError = try XCTUnwrap(sut.errors.last as? URLError)
+                let firstError = try XCTUnwrap(sut.thrownErrors.first as? URLError)
+                let lastError = try XCTUnwrap(sut.thrownErrors.last as? URLError)
 
                 XCTAssertEqual(firstError.code, .badURL)
                 XCTAssertEqual(lastError.code, .badServerResponse)
@@ -83,14 +83,14 @@ final class MockVoidThrowingFunctionWithoutParametersTests: XCTestCase {
         }
     }
 
-    // MARK: Latest Error Tests
+    // MARK: Last Error Tests
 
-    func testLatestError() throws {
+    func testLastError() throws {
         try self.test { sut, invoke in
-            XCTAssertNil(sut.latestError)
+            XCTAssertNil(sut.lastThrownError)
 
             _ = try invoke()
-            XCTAssertNil(sut.latestError)
+            XCTAssertNil(sut.lastThrownError)
 
             sut.error = URLError(.badURL)
 
@@ -100,9 +100,9 @@ final class MockVoidThrowingFunctionWithoutParametersTests: XCTestCase {
             } catch let error as URLError {
                 XCTAssertEqual(error.code, .badURL)
 
-                let latestError = try XCTUnwrap(sut.latestError as? URLError)
+                let lastError = try XCTUnwrap(sut.lastThrownError as? URLError)
 
-                XCTAssertEqual(latestError.code, .badURL)
+                XCTAssertEqual(lastError.code, .badURL)
             } catch {
                 XCTFail("Expected \(error) to equal URLError(.badURL)")
             }
@@ -115,9 +115,9 @@ final class MockVoidThrowingFunctionWithoutParametersTests: XCTestCase {
             } catch let error as URLError {
                 XCTAssertEqual(error.code, .badServerResponse)
 
-                let latestError = try XCTUnwrap(sut.latestError as? URLError)
+                let lastError = try XCTUnwrap(sut.lastThrownError as? URLError)
 
-                XCTAssertEqual(latestError.code, .badServerResponse)
+                XCTAssertEqual(lastError.code, .badServerResponse)
             } catch {
                 XCTFail("Expected \(error) to equal URLError(.badServerResponse)")
             }


### PR DESCRIPTION
# Summary
- Renamed mock properties:
  - `latestInvocation` to `lastInvocation`
  - `returnValues` to `returnedValues`
  - `latestReturnValue` to `lastReturnedValue`
  - `errors` to `thrownErrors`
  - `latestError` to `lastThrownError`
  - `values` to `invocations`
  - `latestValue` to `lastInvocation`
- Added mock properties to:
  - `MockVariableAsyncGetter`
  - `MockVariableAsyncThrowingGetter`
  - `MockVariableGetter`
  - `MockVariableThrowingGetter`