### PR TITLE
Remove mutating and nonmutating modifiers from generated mocks

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         ),
         .package(
             url: "git@github.com:fetch-rewards/SwiftSyntaxSugar.git",
-            branch: "refactor/optional-arrays"
+            branch: "refactor/SyntaxProtocol-with"
         ),
         .package(
             url: "https://github.com/pointfreeco/xctest-dynamic-overlay",

--- a/Tests/MockedMacrosTests/Mocked_ReadOnlyPropertyTests.swift
+++ b/Tests/MockedMacrosTests/Mocked_ReadOnlyPropertyTests.swift
@@ -44,6 +44,64 @@ final class Mocked_ReadOnlyPropertyTests: XCTestCase {
         }
     }
 
+    func testReadOnlyPropertyWithMutatingGet() {
+        testMocked { interface, mock in
+            assertMocked(
+                """
+                \(interface.accessLevel) protocol Dependency {
+                    var property: String { mutating get }
+                }
+                """,
+                generates: """
+                    \(mock.modifiers)class DependencyMock: Dependency {
+                    \(mock.defaultInit)
+                        private let __property = MockReadOnlyProperty<String>.makeProperty(
+                            exposedPropertyDescription: MockImplementationDescription(
+                                type: DependencyMock.self,
+                                member: "_property"
+                            )
+                        )
+                        \(mock.memberModifiers)var _property: MockReadOnlyProperty<String> {
+                            self.__property.property
+                        }
+                        \(mock.memberModifiers)var property: String {
+                            self.__property.get()
+                        }
+                    }
+                    """
+            )
+        }
+    }
+
+    func testReadOnlyPropertyWithNonMutatingGet() {
+        testMocked { interface, mock in
+            assertMocked(
+                """
+                \(interface.accessLevel) protocol Dependency {
+                    var property: String { nonmutating get }
+                }
+                """,
+                generates: """
+                    \(mock.modifiers)class DependencyMock: Dependency {
+                    \(mock.defaultInit)
+                        private let __property = MockReadOnlyProperty<String>.makeProperty(
+                            exposedPropertyDescription: MockImplementationDescription(
+                                type: DependencyMock.self,
+                                member: "_property"
+                            )
+                        )
+                        \(mock.memberModifiers)var _property: MockReadOnlyProperty<String> {
+                            self.__property.property
+                        }
+                        \(mock.memberModifiers)var property: String {
+                            self.__property.get()
+                        }
+                    }
+                    """
+            )
+        }
+    }
+
     // MARK: Read-Only Async Property Tests
 
     func testReadOnlyAsyncProperty() {
@@ -52,6 +110,68 @@ final class Mocked_ReadOnlyPropertyTests: XCTestCase {
                 """
                 \(interface.accessLevel) protocol Dependency {
                     var property: String { get async }
+                }
+                """,
+                generates: """
+                    \(mock.modifiers)class DependencyMock: Dependency {
+                    \(mock.defaultInit)
+                        private let __property = MockReadOnlyAsyncProperty<String>.makeProperty(
+                            exposedPropertyDescription: MockImplementationDescription(
+                                type: DependencyMock.self,
+                                member: "_property"
+                            )
+                        )
+                        \(mock.memberModifiers)var _property: MockReadOnlyAsyncProperty<String> {
+                            self.__property.property
+                        }
+                        \(mock.memberModifiers)var property: String {
+                            get async {
+                                await self.__property.get()
+                            }
+                        }
+                    }
+                    """
+            )
+        }
+    }
+
+    func testReadOnlyAsyncPropertyWithMutatingGet() {
+        testMocked { interface, mock in
+            assertMocked(
+                """
+                \(interface.accessLevel) protocol Dependency {
+                    var property: String { mutating get async }
+                }
+                """,
+                generates: """
+                    \(mock.modifiers)class DependencyMock: Dependency {
+                    \(mock.defaultInit)
+                        private let __property = MockReadOnlyAsyncProperty<String>.makeProperty(
+                            exposedPropertyDescription: MockImplementationDescription(
+                                type: DependencyMock.self,
+                                member: "_property"
+                            )
+                        )
+                        \(mock.memberModifiers)var _property: MockReadOnlyAsyncProperty<String> {
+                            self.__property.property
+                        }
+                        \(mock.memberModifiers)var property: String {
+                            get async {
+                                await self.__property.get()
+                            }
+                        }
+                    }
+                    """
+            )
+        }
+    }
+
+    func testReadOnlyAsyncPropertyWithNonMutatingGet() {
+        testMocked { interface, mock in
+            assertMocked(
+                """
+                \(interface.accessLevel) protocol Dependency {
+                    var property: String { nonmutating get async }
                 }
                 """,
                 generates: """
@@ -110,6 +230,68 @@ final class Mocked_ReadOnlyPropertyTests: XCTestCase {
         }
     }
 
+    func testReadOnlyThrowingPropertyWithMutatingGet() {
+        testMocked { interface, mock in
+            assertMocked(
+                """
+                \(interface.accessLevel) protocol Dependency {
+                    var property: String { mutating get throws }
+                }
+                """,
+                generates: """
+                    \(mock.modifiers)class DependencyMock: Dependency {
+                    \(mock.defaultInit)
+                        private let __property = MockReadOnlyThrowingProperty<String>.makeProperty(
+                            exposedPropertyDescription: MockImplementationDescription(
+                                type: DependencyMock.self,
+                                member: "_property"
+                            )
+                        )
+                        \(mock.memberModifiers)var _property: MockReadOnlyThrowingProperty<String> {
+                            self.__property.property
+                        }
+                        \(mock.memberModifiers)var property: String {
+                            get throws {
+                                try self.__property.get()
+                            }
+                        }
+                    }
+                    """
+            )
+        }
+    }
+
+    func testReadOnlyThrowingPropertyWithNonMutatingGet() {
+        testMocked { interface, mock in
+            assertMocked(
+                """
+                \(interface.accessLevel) protocol Dependency {
+                    var property: String { nonmutating get throws }
+                }
+                """,
+                generates: """
+                    \(mock.modifiers)class DependencyMock: Dependency {
+                    \(mock.defaultInit)
+                        private let __property = MockReadOnlyThrowingProperty<String>.makeProperty(
+                            exposedPropertyDescription: MockImplementationDescription(
+                                type: DependencyMock.self,
+                                member: "_property"
+                            )
+                        )
+                        \(mock.memberModifiers)var _property: MockReadOnlyThrowingProperty<String> {
+                            self.__property.property
+                        }
+                        \(mock.memberModifiers)var property: String {
+                            get throws {
+                                try self.__property.get()
+                            }
+                        }
+                    }
+                    """
+            )
+        }
+    }
+
     // MARK: Read-Only Async Throwing Property Tests
 
     func testReadOnlyAsyncThrowingProperty() {
@@ -118,6 +300,70 @@ final class Mocked_ReadOnlyPropertyTests: XCTestCase {
                 """
                 \(interface.accessLevel) protocol Dependency {
                     var property: String { get async throws }
+                }
+                """,
+                generates: """
+                    \(mock.modifiers)class DependencyMock: Dependency {
+                    \(mock.defaultInit)
+                        private let __property = MockReadOnlyAsyncThrowingProperty<String>.makeProperty(
+                            exposedPropertyDescription: MockImplementationDescription(
+                                type: DependencyMock.self,
+                                member: "_property"
+                            )
+                        )
+                        \(mock.memberModifiers)\
+                    var _property: MockReadOnlyAsyncThrowingProperty<String> {
+                            self.__property.property
+                        }
+                        \(mock.memberModifiers)var property: String {
+                            get async throws {
+                                try await self.__property.get()
+                            }
+                        }
+                    }
+                    """
+            )
+        }
+    }
+
+    func testReadOnlyAsyncThrowingPropertyWithMutatingGet() {
+        testMocked { interface, mock in
+            assertMocked(
+                """
+                \(interface.accessLevel) protocol Dependency {
+                    var property: String { mutating get async throws }
+                }
+                """,
+                generates: """
+                    \(mock.modifiers)class DependencyMock: Dependency {
+                    \(mock.defaultInit)
+                        private let __property = MockReadOnlyAsyncThrowingProperty<String>.makeProperty(
+                            exposedPropertyDescription: MockImplementationDescription(
+                                type: DependencyMock.self,
+                                member: "_property"
+                            )
+                        )
+                        \(mock.memberModifiers)\
+                    var _property: MockReadOnlyAsyncThrowingProperty<String> {
+                            self.__property.property
+                        }
+                        \(mock.memberModifiers)var property: String {
+                            get async throws {
+                                try await self.__property.get()
+                            }
+                        }
+                    }
+                    """
+            )
+        }
+    }
+
+    func testReadOnlyAsyncThrowingPropertyWithNonMutatingGet() {
+        testMocked { interface, mock in
+            assertMocked(
+                """
+                \(interface.accessLevel) protocol Dependency {
+                    var property: String { nonmutating get async throws }
                 }
                 """,
                 generates: """

--- a/Tests/MockedMacrosTests/Mocked_ReadWritePropertyTests.swift
+++ b/Tests/MockedMacrosTests/Mocked_ReadWritePropertyTests.swift
@@ -48,5 +48,277 @@ final class Mocked_ReadWritePropertyTests: XCTestCase {
             )
         }
     }
+
+    func testReadWritePropertyWithMutatingGet() {
+        testMocked { interface, mock in
+            assertMocked(
+                """
+                \(interface.accessLevel) protocol Dependency {
+                    var property: String { mutating get set }
+                }
+                """,
+                generates: """
+                    \(mock.modifiers)class DependencyMock: Dependency {
+                    \(mock.defaultInit)
+                        private let __property = MockReadWriteProperty<String>.makeProperty(
+                            exposedPropertyDescription: MockImplementationDescription(
+                                type: DependencyMock.self,
+                                member: "_property"
+                            )
+                        )
+                        \(mock.memberModifiers)var _property: MockReadWriteProperty<String> {
+                            self.__property.property
+                        }
+                        \(mock.memberModifiers)var property: String {
+                            get {
+                                self.__property.get()
+                            }
+                            set {
+                                self.__property.set(newValue)
+                            }
+                        }
+                    }
+                    """
+            )
+        }
+    }
+
+    func testReadWritePropertyWithNonMutatingGet() {
+        testMocked { interface, mock in
+            assertMocked(
+                """
+                \(interface.accessLevel) protocol Dependency {
+                    var property: String { nonmutating get set }
+                }
+                """,
+                generates: """
+                    \(mock.modifiers)class DependencyMock: Dependency {
+                    \(mock.defaultInit)
+                        private let __property = MockReadWriteProperty<String>.makeProperty(
+                            exposedPropertyDescription: MockImplementationDescription(
+                                type: DependencyMock.self,
+                                member: "_property"
+                            )
+                        )
+                        \(mock.memberModifiers)var _property: MockReadWriteProperty<String> {
+                            self.__property.property
+                        }
+                        \(mock.memberModifiers)var property: String {
+                            get {
+                                self.__property.get()
+                            }
+                            set {
+                                self.__property.set(newValue)
+                            }
+                        }
+                    }
+                    """
+            )
+        }
+    }
+
+    func testReadWritePropertyWithMutatingSet() {
+        testMocked { interface, mock in
+            assertMocked(
+                """
+                \(interface.accessLevel) protocol Dependency {
+                    var property: String { get mutating set }
+                }
+                """,
+                generates: """
+                    \(mock.modifiers)class DependencyMock: Dependency {
+                    \(mock.defaultInit)
+                        private let __property = MockReadWriteProperty<String>.makeProperty(
+                            exposedPropertyDescription: MockImplementationDescription(
+                                type: DependencyMock.self,
+                                member: "_property"
+                            )
+                        )
+                        \(mock.memberModifiers)var _property: MockReadWriteProperty<String> {
+                            self.__property.property
+                        }
+                        \(mock.memberModifiers)var property: String {
+                            get {
+                                self.__property.get()
+                            }
+                            set {
+                                self.__property.set(newValue)
+                            }
+                        }
+                    }
+                    """
+            )
+        }
+    }
+
+    func testReadWritePropertyWithNonMutatingSet() {
+        testMocked { interface, mock in
+            assertMocked(
+                """
+                \(interface.accessLevel) protocol Dependency {
+                    var property: String { get nonmutating set }
+                }
+                """,
+                generates: """
+                    \(mock.modifiers)class DependencyMock: Dependency {
+                    \(mock.defaultInit)
+                        private let __property = MockReadWriteProperty<String>.makeProperty(
+                            exposedPropertyDescription: MockImplementationDescription(
+                                type: DependencyMock.self,
+                                member: "_property"
+                            )
+                        )
+                        \(mock.memberModifiers)var _property: MockReadWriteProperty<String> {
+                            self.__property.property
+                        }
+                        \(mock.memberModifiers)var property: String {
+                            get {
+                                self.__property.get()
+                            }
+                            set {
+                                self.__property.set(newValue)
+                            }
+                        }
+                    }
+                    """
+            )
+        }
+    }
+
+    func testReadWritePropertyWithMutatingGetAndMutatingSet() {
+        testMocked { interface, mock in
+            assertMocked(
+                """
+                \(interface.accessLevel) protocol Dependency {
+                    var property: String { mutating get mutating set }
+                }
+                """,
+                generates: """
+                    \(mock.modifiers)class DependencyMock: Dependency {
+                    \(mock.defaultInit)
+                        private let __property = MockReadWriteProperty<String>.makeProperty(
+                            exposedPropertyDescription: MockImplementationDescription(
+                                type: DependencyMock.self,
+                                member: "_property"
+                            )
+                        )
+                        \(mock.memberModifiers)var _property: MockReadWriteProperty<String> {
+                            self.__property.property
+                        }
+                        \(mock.memberModifiers)var property: String {
+                            get {
+                                self.__property.get()
+                            }
+                            set {
+                                self.__property.set(newValue)
+                            }
+                        }
+                    }
+                    """
+            )
+        }
+    }
+
+    func testReadWritePropertyWithNonMutatingGetAndMutatingSet() {
+        testMocked { interface, mock in
+            assertMocked(
+                """
+                \(interface.accessLevel) protocol Dependency {
+                    var property: String { nonmutating get mutating set }
+                }
+                """,
+                generates: """
+                    \(mock.modifiers)class DependencyMock: Dependency {
+                    \(mock.defaultInit)
+                        private let __property = MockReadWriteProperty<String>.makeProperty(
+                            exposedPropertyDescription: MockImplementationDescription(
+                                type: DependencyMock.self,
+                                member: "_property"
+                            )
+                        )
+                        \(mock.memberModifiers)var _property: MockReadWriteProperty<String> {
+                            self.__property.property
+                        }
+                        \(mock.memberModifiers)var property: String {
+                            get {
+                                self.__property.get()
+                            }
+                            set {
+                                self.__property.set(newValue)
+                            }
+                        }
+                    }
+                    """
+            )
+        }
+    }
+
+    func testReadWritePropertyWithMutatingGetAndNonMutatingSet() {
+        testMocked { interface, mock in
+            assertMocked(
+                """
+                \(interface.accessLevel) protocol Dependency {
+                    var property: String { mutating get nonmutating set }
+                }
+                """,
+                generates: """
+                    \(mock.modifiers)class DependencyMock: Dependency {
+                    \(mock.defaultInit)
+                        private let __property = MockReadWriteProperty<String>.makeProperty(
+                            exposedPropertyDescription: MockImplementationDescription(
+                                type: DependencyMock.self,
+                                member: "_property"
+                            )
+                        )
+                        \(mock.memberModifiers)var _property: MockReadWriteProperty<String> {
+                            self.__property.property
+                        }
+                        \(mock.memberModifiers)var property: String {
+                            get {
+                                self.__property.get()
+                            }
+                            set {
+                                self.__property.set(newValue)
+                            }
+                        }
+                    }
+                    """
+            )
+        }
+    }
+
+    func testReadWritePropertyWithNonMutatingGetAndNonMutatingSet() {
+        testMocked { interface, mock in
+            assertMocked(
+                """
+                \(interface.accessLevel) protocol Dependency {
+                    var property: String { nonmutating get nonmutating set }
+                }
+                """,
+                generates: """
+                    \(mock.modifiers)class DependencyMock: Dependency {
+                    \(mock.defaultInit)
+                        private let __property = MockReadWriteProperty<String>.makeProperty(
+                            exposedPropertyDescription: MockImplementationDescription(
+                                type: DependencyMock.self,
+                                member: "_property"
+                            )
+                        )
+                        \(mock.memberModifiers)var _property: MockReadWriteProperty<String> {
+                            self.__property.property
+                        }
+                        \(mock.memberModifiers)var property: String {
+                            get {
+                                self.__property.get()
+                            }
+                            set {
+                                self.__property.set(newValue)
+                            }
+                        }
+                    }
+                    """
+            )
+        }
+    }
 }
 #endif


### PR DESCRIPTION
## Summary
- Resolved #36:
  - Removed `mutating` and `nonmutating` modifiers from function declarations and variable accessors in generated mocks.
- Added unit tests.