### PR TITLE
Refactor using Locked's new init accessors

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "git@github.com:fetch-rewards/swift-locking.git",
-            revision: "72c51636ce63d48472a97b87aad305c872b57569"
+            revision: "00244dc3f08de5fb2c31d9026c35e5830175fd05"
         ),
         .package(
             url: "https://github.com/apple/swift-syntax.git",

--- a/Sources/Mocked/MockProperties/MockReadOnlyAsyncProperty.swift
+++ b/Sources/Mocked/MockProperties/MockReadOnlyAsyncProperty.swift
@@ -25,10 +25,8 @@ public final class MockReadOnlyAsyncProperty<Value> {
     /// - Parameter exposedPropertyDescription: The description of the mock's
     ///   exposed property.
     private init(exposedPropertyDescription: MockImplementationDescription) {
-        self._getter = OSAllocatedUnfairLock(
-            uncheckedState: MockPropertyAsyncGetter(
-                exposedPropertyDescription: exposedPropertyDescription
-            )
+        self.getter = MockPropertyAsyncGetter(
+            exposedPropertyDescription: exposedPropertyDescription
         )
     }
 

--- a/Sources/Mocked/MockProperties/MockReadOnlyAsyncThrowingProperty.swift
+++ b/Sources/Mocked/MockProperties/MockReadOnlyAsyncThrowingProperty.swift
@@ -25,10 +25,8 @@ public final class MockReadOnlyAsyncThrowingProperty<Value> {
     /// - Parameter exposedPropertyDescription: The description of the mock's
     ///   exposed property.
     private init(exposedPropertyDescription: MockImplementationDescription) {
-        self._getter = OSAllocatedUnfairLock(
-            uncheckedState: MockPropertyAsyncThrowingGetter(
-                exposedPropertyDescription: exposedPropertyDescription
-            )
+        self.getter = MockPropertyAsyncThrowingGetter(
+            exposedPropertyDescription: exposedPropertyDescription
         )
     }
 

--- a/Sources/Mocked/MockProperties/MockReadOnlyProperty.swift
+++ b/Sources/Mocked/MockProperties/MockReadOnlyProperty.swift
@@ -25,10 +25,8 @@ public final class MockReadOnlyProperty<Value> {
     /// - Parameter exposedPropertyDescription: The description of the mock's
     ///   exposed property.
     private init(exposedPropertyDescription: MockImplementationDescription) {
-        self._getter = OSAllocatedUnfairLock(
-            uncheckedState: MockPropertyGetter(
-                exposedPropertyDescription: exposedPropertyDescription
-            )
+        self.getter = MockPropertyGetter(
+            exposedPropertyDescription: exposedPropertyDescription
         )
     }
 

--- a/Sources/Mocked/MockProperties/MockReadOnlyThrowingProperty.swift
+++ b/Sources/Mocked/MockProperties/MockReadOnlyThrowingProperty.swift
@@ -25,10 +25,8 @@ public final class MockReadOnlyThrowingProperty<Value> {
     /// - Parameter exposedPropertyDescription: The description of the mock's
     ///   exposed property.
     private init(exposedPropertyDescription: MockImplementationDescription) {
-        self._getter = OSAllocatedUnfairLock(
-            uncheckedState: MockPropertyThrowingGetter(
-                exposedPropertyDescription: exposedPropertyDescription
-            )
+        self.getter = MockPropertyThrowingGetter(
+            exposedPropertyDescription: exposedPropertyDescription
         )
     }
 

--- a/Sources/Mocked/MockProperties/MockReadWriteProperty.swift
+++ b/Sources/Mocked/MockProperties/MockReadWriteProperty.swift
@@ -29,10 +29,8 @@ public final class MockReadWriteProperty<Value> {
     /// - Parameter exposedPropertyDescription: The description of the mock's
     ///   exposed property.
     private init(exposedPropertyDescription: MockImplementationDescription) {
-        self._getter = OSAllocatedUnfairLock(
-            uncheckedState: MockPropertyGetter(
-                exposedPropertyDescription: exposedPropertyDescription
-            )
+        self.getter = MockPropertyGetter(
+            exposedPropertyDescription: exposedPropertyDescription
         )
     }
 


### PR DESCRIPTION
## Summary
- Updated `swift-locking` dependency.
- Refactored getter initialization using Locked's new init accessors.