### PR TITLE
Fix PR template links

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -52,5 +52,5 @@ Please link any related PRs, for example:
 - [ ] I have formatted my code using `SwiftFormat`
 - [ ] I have updated documentation (if needed)
 - [ ] I have added the appropriate label to my PR
-- [ ] I have read the [contributing guidelines](https://github.com/fetch-rewards/swift-synchronization/blob/main/CONTRIBUTING.md)
-- [ ] I agree to follow this project's [Code of Conduct](https://github.com/fetch-rewards/swift-synchronization/blob/main/CODE_OF_CONDUCT.md)
+- [ ] I have read the [contributing guidelines](https://github.com/fetch-rewards/swift-mocking/blob/main/CONTRIBUTING.md)
+- [ ] I agree to follow this project's [Code of Conduct](https://github.com/fetch-rewards/swift-mocking/blob/main/CODE_OF_CONDUCT.md)


### PR DESCRIPTION
## 📝 Summary

<!-- 
Please provide a brief summary of your changes along with any relevant context.
Include any screenshots, logs, or terminal output you think would be helpful to reviewers.
-->

- Fixed links in PR template that were pointing to [swift-synchronization](https://github.com/fetch-rewards/swift-synchronization).

## 🛠️ Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds functionality)
- [ ] Breaking change (bug fix or feature that is not backwards compatible)
- [x] Documentation (DocC, API docs, markdown files, templates, etc.)
- [ ] Testing (new tests, updated tests, etc.)
- [ ] Refactoring or code formatting (no logic changes)
- [ ] Updating dependencies (Swift packages, Homebrew, etc.)
- [ ] CI/CD (change to automated workflows)

## ✅ Checklist

<!-- Confirm that you've completed the following steps. -->

- [x] I have added relevant tests
- [x] I have verified all tests pass
- [x] I have formatted my code using `SwiftFormat`
- [x] I have updated documentation (if needed)
- [x] I have added the appropriate label to my PR
- [x] I have read the [contributing guidelines](https://github.com/fetch-rewards/swift-mocking/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/fetch-rewards/swift-mocking/blob/main/CODE_OF_CONDUCT.md)