### PR TITLE
Handle composed and mixed associated type constraints

### DIFF
--- a/Sources/MockingClient/MethodOverloads.swift
+++ b/Sources/MockingClient/MethodOverloads.swift
@@ -4,7 +4,7 @@
 //  Copyright © 2025 Fetch.
 //
 
-// swiftformat:disable opaqueGenericParameters trailingSpace
+// swiftformat:disable opaqueGenericParameters
 
 import Foundation
 public import Mocking

--- a/Sources/MockingClient/MethodOverloads.swift
+++ b/Sources/MockingClient/MethodOverloads.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2025 Fetch.
 //
 
+// swiftformat:disable opaqueGenericParameters trailingSpace
+
 import Foundation
 public import Mocking
 

--- a/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
+++ b/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
@@ -151,20 +151,21 @@ extension MockedMacro {
         return GenericParameterClauseSyntax {
             for associatedTypeDeclaration in associatedTypeDeclarations {
                 let genericParameterName = associatedTypeDeclaration.name.trimmed
-                
+
                 if let inheritanceClause = associatedTypeDeclaration.inheritanceClause {
                     let commaSeparatedInheritedTypes = inheritanceClause
                         .inheritedTypes(ofType: IdentifierTypeSyntax.self)
-                    
+
                     let composedInheritedTypes = inheritanceClause
                         .inheritedTypes(ofType: CompositionTypeSyntax.self)
                         .flatMap(\.elements)
                         .compactMap { $0.type.as(IdentifierTypeSyntax.self) }
 
-                    let genericInheritedType = (commaSeparatedInheritedTypes + composedInheritedTypes)
-                        .map(\.name.text)
-                        .joined(separator: " & ")
-                    
+                    let genericInheritedType =
+                        (commaSeparatedInheritedTypes + composedInheritedTypes)
+                            .map(\.name.text)
+                            .joined(separator: " & ")
+
                     GenericParameterSyntax(
                         name: genericParameterName,
                         colon: .colonToken(),

--- a/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
+++ b/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
@@ -120,13 +120,16 @@ extension MockedMacro {
     /// Returns the generic parameter clause to apply to the mock declaration,
     /// generated from the associated types defined by the provided protocol.
     ///
+    /// The clause supports associated types with comma-separated constraints,
+    /// composition (`&`), or a combination of both.
+    ///
     /// ```swift
     /// @Mocked
     /// protocol Dependency {
-    ///     associatedtype Item: Equatable, Identifiable
+    ///     associatedtype Item: Equatable & Identifiable, Sendable
     /// }
     ///
-    /// final class DependencyMock<Item: Equatable & Identifiable>: Dependency {}
+    /// final class DependencyMock<Item: Sendable & Equatable & Identifiable>: Dependency {}
     /// ```
     ///
     /// - Parameter protocolDeclaration: The protocol to which the mock must
@@ -148,12 +151,20 @@ extension MockedMacro {
         return GenericParameterClauseSyntax {
             for associatedTypeDeclaration in associatedTypeDeclarations {
                 let genericParameterName = associatedTypeDeclaration.name.trimmed
-                let genericInheritedType = associatedTypeDeclaration.inheritanceClause?
-                    .inheritedTypes(ofType: IdentifierTypeSyntax.self)
-                    .map(\.name.text)
-                    .joined(separator: " & ")
+                
+                if let inheritanceClause = associatedTypeDeclaration.inheritanceClause {
+                    let commaSeparatedInheritedTypes = inheritanceClause
+                        .inheritedTypes(ofType: IdentifierTypeSyntax.self)
+                    
+                    let composedInheritedTypes = inheritanceClause
+                        .inheritedTypes(ofType: CompositionTypeSyntax.self)
+                        .flatMap(\.elements)
+                        .compactMap { $0.type.as(IdentifierTypeSyntax.self) }
 
-                if let genericInheritedType {
+                    let genericInheritedType = (commaSeparatedInheritedTypes + composedInheritedTypes)
+                        .map(\.name.text)
+                        .joined(separator: " & ")
+                    
                     GenericParameterSyntax(
                         name: genericParameterName,
                         colon: .colonToken(),

--- a/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
+++ b/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
@@ -155,22 +155,26 @@ extension MockedMacro {
                 if let inheritanceClause = associatedTypeDeclaration.inheritanceClause {
                     let commaSeparatedInheritedTypes = inheritanceClause
                         .inheritedTypes(ofType: IdentifierTypeSyntax.self)
+                        .compactMap { CompositionTypeElementSyntax(type: $0) }
 
                     let composedInheritedTypes = inheritanceClause
                         .inheritedTypes(ofType: CompositionTypeSyntax.self)
                         .flatMap(\.elements)
-                        .compactMap { $0.type.as(IdentifierTypeSyntax.self) }
 
                     let inheritedTypes = commaSeparatedInheritedTypes + composedInheritedTypes
-
-                    let genericInheritedType = inheritedTypes
-                            .map(\.name.text)
-                            .joined(separator: " & ")
+                    let lastIndex = inheritedTypes.count - 1
+                    let inheritedTypeElements = CompositionTypeElementListSyntax {
+                        for (index, inheritedType) in inheritedTypes.enumerated() {
+                            inheritedType
+                                .trimmed
+                                .with(\.ampersand, index < lastIndex ? .binaryOperator("&") : nil)
+                        }
+                    }
 
                     GenericParameterSyntax(
                         name: genericParameterName,
                         colon: .colonToken(),
-                        inheritedType: TypeSyntax(stringLiteral: genericInheritedType)
+                        inheritedType: CompositionTypeSyntax(elements: inheritedTypeElements)
                     )
                 } else {
                     GenericParameterSyntax(name: genericParameterName)

--- a/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
+++ b/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
@@ -161,8 +161,9 @@ extension MockedMacro {
                         .flatMap(\.elements)
                         .compactMap { $0.type.as(IdentifierTypeSyntax.self) }
 
-                    let genericInheritedType =
-                        (commaSeparatedInheritedTypes + composedInheritedTypes)
+                    let inheritedTypes = commaSeparatedInheritedTypes + composedInheritedTypes
+
+                    let genericInheritedType = inheritedTypes
                             .map(\.name.text)
                             .joined(separator: " & ")
 

--- a/Tests/MockingMacrosTests/Macros/MockedMacro/Mocked_AssociatedTypeTests.swift
+++ b/Tests/MockingMacrosTests/Macros/MockedMacro/Mocked_AssociatedTypeTests.swift
@@ -60,7 +60,7 @@ struct Mocked_AssociatedTypeTests {
             """
         )
     }
-    
+
     @Test(arguments: mockedTestConfigurations)
     func protocolAssociatedTypeInheritanceWithMultipleComposedInheritedTypes(
         interface: InterfaceConfiguration,
@@ -86,7 +86,7 @@ struct Mocked_AssociatedTypeTests {
             """
         )
     }
-    
+
     @Test(arguments: mockedTestConfigurations)
     func protocolAssociatedTypeInheritanceWithMultipleMixedInheritedTypes(
         interface: InterfaceConfiguration,

--- a/Tests/MockingMacrosTests/Macros/MockedMacro/Mocked_AssociatedTypeTests.swift
+++ b/Tests/MockingMacrosTests/Macros/MockedMacro/Mocked_AssociatedTypeTests.swift
@@ -36,7 +36,7 @@ struct Mocked_AssociatedTypeTests {
     }
 
     @Test(arguments: mockedTestConfigurations)
-    func protocolAssociatedTypeInheritanceWithMultipleInheritedTypes(
+    func protocolAssociatedTypeInheritanceWithMultipleCommaSeparatedInheritedTypes(
         interface: InterfaceConfiguration,
         mock: MockConfiguration
     ) {
@@ -54,6 +54,56 @@ struct Mocked_AssociatedTypeTests {
             class DependencyMock<\
             A: Hashable & Identifiable, \
             B: Comparable & Equatable & RawRepresentable\
+            >: Dependency {
+            }
+            #endif
+            """
+        )
+    }
+    
+    @Test(arguments: mockedTestConfigurations)
+    func protocolAssociatedTypeInheritanceWithMultipleComposedInheritedTypes(
+        interface: InterfaceConfiguration,
+        mock: MockConfiguration
+    ) {
+        assertMocked(
+            """
+            \(interface.accessLevel) protocol Dependency {
+                associatedtype A: Hashable & Identifiable
+                associatedtype B: Comparable & Equatable & RawRepresentable
+            }
+            """,
+            generates: """
+            #if SWIFT_MOCKING_ENABLED
+            @MockedMembers
+            \(mock.modifiers)\
+            class DependencyMock<\
+            A: Hashable & Identifiable, \
+            B: Comparable & Equatable & RawRepresentable\
+            >: Dependency {
+            }
+            #endif
+            """
+        )
+    }
+    
+    @Test(arguments: mockedTestConfigurations)
+    func protocolAssociatedTypeInheritanceWithMultipleMixedInheritedTypes(
+        interface: InterfaceConfiguration,
+        mock: MockConfiguration
+    ) {
+        assertMocked(
+            """
+            \(interface.accessLevel) protocol Dependency {
+                associatedtype A: Sendable, Hashable & Identifiable 
+            }
+            """,
+            generates: """
+            #if SWIFT_MOCKING_ENABLED
+            @MockedMembers
+            \(mock.modifiers)\
+            class DependencyMock<\
+            A: Sendable & Hashable & Identifiable\
             >: Dependency {
             }
             #endif


### PR DESCRIPTION
## 📝 Summary

This pull request fixes a bug in `MockedMacro.mockGenericParameterClause` where associated types using composition (`&`) in their constraints weren’t handled correctly.

Previously, the `@Mocked` assumed all inherited types were `IdentifierTypeSyntax` nodes, which holds for comma-separated constraints (e.g. `Hashable, Sendable`). However, composed constraints (e.g. `Hashable & Sendable`) are represented in the syntax tree as `CompositionTypeSyntax`, which nests multiple `IdentifierTypeSyntax` elements. As a result, these weren’t being parsed, and the generated generic parameter clause was incomplete or incorrect.

To fix this, I've:
* Updated `mockGenericParameterClause` to correctly extract constraints from both `IdentifierTypeSyntax` and nested `CompositionTypeSyntax`.
* Added unit test coverage to catch composed constraints and mixed cases going forward.

## 🛠️ Type of Change

- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds functionality)
- [ ] Breaking change (bug fix or feature that is not backwards compatible)
- [x] Documentation (DocC, API docs, markdown files, templates, etc.)
- [x] Testing (new tests, updated tests, etc.)
- [ ] Refactoring or code formatting (no logic changes)
- [ ] Updating dependencies (Swift packages, Homebrew, etc.)
- [ ] CI/CD (change to automated workflows)

## 🧪 How Has This Been Tested?

I've tested the `@Mocked` macro expansion when an `associatedtype` has constraints that are comma-separated, composed, or a mix of both. Please see screenshots of the expansion below.
I've also added unit tests to validate these scenarios going forward.

|Constraint scenario|`@Mocked` expansion|
|-----|-----|
|Comma-separated|![CommaSeparated](https://github.com/user-attachments/assets/ca30df5a-e8b7-47e8-add6-277f70e06c1f)|
|Composed|![Composed](https://github.com/user-attachments/assets/af72e3c3-56e7-4335-b8e7-e7fb0b0ed0f6)|
|Mixed|![Mixed](https://github.com/user-attachments/assets/01dc96b2-7006-4331-a02e-f3d957ed53d9)|

## 🔗 Related PRs or Issues <!-- Delete section if not applicable -->

- Fixes #107

## ✅ Checklist

- [x] I have added relevant tests
- [x] I have verified all tests pass
- [x] I have formatted my code using `SwiftFormat`
- [x] I have updated documentation (if needed)
- [x] I have added the appropriate label to my PR
- [x] I have read the [contributing guidelines](https://github.com/fetch-rewards/swift-mocking/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/fetch-rewards/swift-mocking/blob/main/CODE_OF_CONDUCT.md)
