### PR TITLE
Update Swift Locking, SwiftSyntaxSugar, and SwiftSyntax dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,16 +24,16 @@ let package = Package(
     ],
     dependencies: [
         .package(
-            url: "https://github.com/fetch-rewards/swift-synchronization.git",
-            exact: "0.1.0"
+            url: "https://github.com/fetch-rewards/swift-locking.git",
+            exact: "0.2.0"
         ),
         .package(
-            url: "https://github.com/apple/swift-syntax.git",
+            url: "https://github.com/swiftlang/swift-syntax.git",
             exact: "600.0.0" // Must match SwiftSyntaxSugar's swift-syntax version
         ),
         .package(
             url: "https://github.com/fetch-rewards/SwiftSyntaxSugar.git",
-            exact: "0.1.0" // Must match swift-synchronization's SwiftSyntaxSugar version
+            exact: "0.1.1" // Must match swift-locking's SwiftSyntaxSugar version
         ),
     ],
     targets: [
@@ -42,8 +42,8 @@ let package = Package(
             dependencies: [
                 "MockingMacros",
                 .product(
-                    name: "Synchronization",
-                    package: "swift-synchronization"
+                    name: "Locking",
+                    package: "swift-locking"
                 ),
             ],
             swiftSettings: .default

--- a/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningNonParameterizedAsyncMethod/MockReturningNonParameterizedAsyncMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningNonParameterizedAsyncMethod/MockReturningNonParameterizedAsyncMethod.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-import Synchronization
+import Locking
 
 /// A mock method that contains implementation details and invocation records
 /// for a returning, non-parameterized, async method.

--- a/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningNonParameterizedAsyncThrowingMethod/MockReturningNonParameterizedAsyncThrowingMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningNonParameterizedAsyncThrowingMethod/MockReturningNonParameterizedAsyncThrowingMethod.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-import Synchronization
+import Locking
 
 /// A mock method that contains implementation details and invocation records
 /// for a returning, non-parameterized, async, throwing method.

--- a/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningNonParameterizedMethod/MockReturningNonParameterizedMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningNonParameterizedMethod/MockReturningNonParameterizedMethod.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-import Synchronization
+import Locking
 
 /// A mock method that contains implementation details and invocation records
 /// for a returning, non-parameterized method.

--- a/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningNonParameterizedThrowingMethod/MockReturningNonParameterizedThrowingMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningNonParameterizedThrowingMethod/MockReturningNonParameterizedThrowingMethod.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-import Synchronization
+import Locking
 
 /// A mock method that contains implementation details and invocation records
 /// for a returning, non-parameterized, throwing method.

--- a/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningParameterizedAsyncMethod/MockReturningParameterizedAsyncMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningParameterizedAsyncMethod/MockReturningParameterizedAsyncMethod.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-import Synchronization
+import Locking
 
 /// A mock method that contains implementation details and invocation records
 /// for a returning, parameterized, async method.

--- a/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningParameterizedAsyncThrowingMethod/MockReturningParameterizedAsyncThrowingMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningParameterizedAsyncThrowingMethod/MockReturningParameterizedAsyncThrowingMethod.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-import Synchronization
+import Locking
 
 /// A mock method that contains implementation details and invocation records
 /// for a returning, parameterized, async, throwing method.

--- a/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningParameterizedMethod/MockReturningParameterizedMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningParameterizedMethod/MockReturningParameterizedMethod.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-import Synchronization
+import Locking
 
 /// A mock method that contains implementation details and invocation records
 /// for a returning, parameterized method.

--- a/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningParameterizedThrowingMethod/MockReturningParameterizedThrowingMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningParameterizedThrowingMethod/MockReturningParameterizedThrowingMethod.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-import Synchronization
+import Locking
 
 /// A mock method that contains implementation details and invocation records
 /// for a returning, parameterized, throwing method.

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidNonParameterizedAsyncMethod/MockVoidNonParameterizedAsyncMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidNonParameterizedAsyncMethod/MockVoidNonParameterizedAsyncMethod.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-import Synchronization
+import Locking
 
 /// A mock method that contains implementation details and invocation records
 /// for a void, non-parameterized, async method.

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidNonParameterizedAsyncThrowingMethod/MockVoidNonParameterizedAsyncThrowingMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidNonParameterizedAsyncThrowingMethod/MockVoidNonParameterizedAsyncThrowingMethod.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-import Synchronization
+import Locking
 
 /// A mock method that contains implementation details and invocation records
 /// for a void, non-parameterized, async, throwing method.

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidNonParameterizedMethod/MockVoidNonParameterizedMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidNonParameterizedMethod/MockVoidNonParameterizedMethod.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-import Synchronization
+import Locking
 
 /// A mock method that contains implementation details and invocation records
 /// for a void, non-parameterized method.

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidNonParameterizedThrowingMethod/MockVoidNonParameterizedThrowingMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidNonParameterizedThrowingMethod/MockVoidNonParameterizedThrowingMethod.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-import Synchronization
+import Locking
 
 /// A mock method that contains implementation details and invocation records
 /// for a void, non-parameterized, throwing method.

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedAsyncMethod/MockVoidParameterizedAsyncMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedAsyncMethod/MockVoidParameterizedAsyncMethod.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-import Synchronization
+import Locking
 
 /// A mock method that contains implementation details and invocation records
 /// for a void, parameterized, async method.

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedAsyncThrowingMethod/MockVoidParameterizedAsyncThrowingMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedAsyncThrowingMethod/MockVoidParameterizedAsyncThrowingMethod.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-import Synchronization
+import Locking
 
 /// A mock method that contains implementation details and invocation records
 /// for a void, parameterized, async, throwing method.

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedMethod/MockVoidParameterizedMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedMethod/MockVoidParameterizedMethod.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-import Synchronization
+import Locking
 
 /// A mock method that contains implementation details and invocation records
 /// for a void, parameterized method.

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedThrowingMethod/MockVoidParameterizedThrowingMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedThrowingMethod/MockVoidParameterizedThrowingMethod.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-import Synchronization
+import Locking
 
 /// A mock method that contains implementation details and invocation records
 /// for a void, parameterized, throwing method.

--- a/Sources/Mocking/Models/MockProperties/MockAccessors/MockPropertyAsyncGetter/MockPropertyAsyncGetter.swift
+++ b/Sources/Mocking/Models/MockProperties/MockAccessors/MockPropertyAsyncGetter/MockPropertyAsyncGetter.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-import Synchronization
+import Locking
 
 /// A mock property getter that contains implementation details and invocation
 /// records for an async property getter.

--- a/Sources/Mocking/Models/MockProperties/MockAccessors/MockPropertyAsyncThrowingGetter/MockPropertyAsyncThrowingGetter.swift
+++ b/Sources/Mocking/Models/MockProperties/MockAccessors/MockPropertyAsyncThrowingGetter/MockPropertyAsyncThrowingGetter.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-import Synchronization
+import Locking
 
 /// A mock property getter that contains implementation details and invocation
 /// records for an async, throwing property getter.

--- a/Sources/Mocking/Models/MockProperties/MockAccessors/MockPropertyGetter/MockPropertyGetter.swift
+++ b/Sources/Mocking/Models/MockProperties/MockAccessors/MockPropertyGetter/MockPropertyGetter.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-import Synchronization
+import Locking
 
 /// A mock property getter that contains implementation details and invocation
 /// records for a property getter.

--- a/Sources/Mocking/Models/MockProperties/MockAccessors/MockPropertySetter/MockPropertySetter.swift
+++ b/Sources/Mocking/Models/MockProperties/MockAccessors/MockPropertySetter/MockPropertySetter.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-import Synchronization
+import Locking
 
 /// A mock property setter that contains implementation details and invocation
 /// records for a property setter.

--- a/Sources/Mocking/Models/MockProperties/MockAccessors/MockPropertyThrowingGetter/MockPropertyThrowingGetter.swift
+++ b/Sources/Mocking/Models/MockProperties/MockAccessors/MockPropertyThrowingGetter/MockPropertyThrowingGetter.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-import Synchronization
+import Locking
 
 /// A mock property getter that contains implementation details and invocation
 /// records for a throwing property getter.

--- a/Sources/Mocking/Models/MockProperties/MockReadOnlyAsyncProperty.swift
+++ b/Sources/Mocking/Models/MockProperties/MockReadOnlyAsyncProperty.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-import Synchronization
+import Locking
 
 /// A mock property that contains implementation details and invocation records
 /// for a read-only, async property.

--- a/Sources/Mocking/Models/MockProperties/MockReadOnlyAsyncThrowingProperty.swift
+++ b/Sources/Mocking/Models/MockProperties/MockReadOnlyAsyncThrowingProperty.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-import Synchronization
+import Locking
 
 /// A mock property that contains implementation details and invocation records
 /// for a read-only, async, throwing property.

--- a/Sources/Mocking/Models/MockProperties/MockReadOnlyProperty.swift
+++ b/Sources/Mocking/Models/MockProperties/MockReadOnlyProperty.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-import Synchronization
+import Locking
 
 /// A mock property that contains implementation details and invocation records
 /// for a read-only property.

--- a/Sources/Mocking/Models/MockProperties/MockReadOnlyThrowingProperty.swift
+++ b/Sources/Mocking/Models/MockProperties/MockReadOnlyThrowingProperty.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-import Synchronization
+import Locking
 
 /// A mock property that contains implementation details and invocation records
 /// for a read-only, throwing property.

--- a/Sources/Mocking/Models/MockProperties/MockReadWriteProperty.swift
+++ b/Sources/Mocking/Models/MockProperties/MockReadWriteProperty.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-import Synchronization
+import Locking
 
 /// A mock property that contains implementation details and invocation records
 /// for a read-write property.


### PR DESCRIPTION
## 📝 Summary

- Updated Swift Locking dependency version to 0.2.0.
- Updated `SwiftSyntaxSugar` dependency version to 0.1.1.
- Updated `SwiftSyntax` dependency URL to `https://github.com/swiftlang/swift-syntax.git`.

## 🛠️ Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds functionality)
- [ ] Breaking change (bug fix or feature that is not backwards compatible)
- [ ] Documentation (DocC, API docs, markdown files, templates, etc.)
- [ ] Testing (new tests, updated tests, etc.)
- [ ] Refactoring or code formatting (no logic changes)
- [x] Updating dependencies (Swift packages, Homebrew, etc.)
- [ ] CI/CD (change to automated workflows)

## 🧪 How Has This Been Tested?

- Existing tests all pass.

## 🔗 Related PRs or Issues <!-- Delete section if not applicable -->

- Resolves #112.

## ✅ Checklist

<!-- Confirm that you've completed the following steps. -->

- [x] I have added relevant tests
- [x] I have verified all tests pass
- [x] I have formatted my code using `SwiftFormat`
- [x] I have updated documentation (if needed)
- [x] I have added the appropriate label to my PR
- [x] I have read the [contributing guidelines](https://github.com/fetch-rewards/swift-mocking/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/fetch-rewards/swift-mocking/blob/main/CODE_OF_CONDUCT.md)