### PR TITLE
Make MockVoidNonParameterizedMethod.Implementation.invokes public

### DIFF
--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidNonParameterizedMethod/MockVoidNonParameterizedMethod+Implementation.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidNonParameterizedMethod/MockVoidNonParameterizedMethod+Implementation.swift
@@ -26,7 +26,7 @@ extension MockVoidNonParameterizedMethod {
         /// Invokes the provided closure when invoked.
         ///
         /// - Parameter closure: The closure to invoke.
-        static func invokes(_ closure: @Sendable @escaping () -> Void) -> Self {
+        public static func invokes(_ closure: @Sendable @escaping () -> Void) -> Self {
             .uncheckedInvokes(closure)
         }
 


### PR DESCRIPTION
## 📝 Summary

- Fixed `MockVoidNonParameterizedMethod.Implementation.invokes` being `internal` instead of `public`.

## 🛠️ Type of Change

<!-- Check all that apply. -->

- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds functionality)
- [ ] Breaking change (bug fix or feature that is not backwards compatible)
- [ ] Documentation (DocC, API docs, markdown files, templates, etc.)
- [ ] Testing (new tests, updated tests, etc.)
- [ ] Refactoring or code formatting (no logic changes)
- [ ] Updating dependencies (Swift packages, Homebrew, etc.)
- [ ] CI/CD (change to automated workflows)

## 🧪 How Has This Been Tested?

- Existing tests all pass.

## ✅ Checklist

<!-- Confirm that you've completed the following steps. -->

- [x] I have added relevant tests
- [x] I have verified all tests pass
- [x] I have formatted my code using `SwiftFormat`
- [x] I have updated documentation (if needed)
- [x] I have added the appropriate label to my PR
- [x] I have read the [contributing guidelines](https://github.com/fetch-rewards/swift-mocking/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/fetch-rewards/swift-mocking/blob/main/CODE_OF_CONDUCT.md)