### PR TITLE
Update callCount and thrownErrors properties to use checked locks

### DIFF
--- a/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningNonParameterizedAsyncMethod/MockReturningNonParameterizedAsyncMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningNonParameterizedAsyncMethod/MockReturningNonParameterizedAsyncMethod.swift
@@ -18,7 +18,7 @@ public final class MockReturningNonParameterizedAsyncMethod<ReturnValue> {
     public var implementation: Implementation = .unimplemented
 
     /// The number of times the method has been called.
-    @Locked(.unchecked)
+    @Locked(.checked)
     public private(set) var callCount: Int = .zero
 
     /// All the values that have been returned by the method.
@@ -103,7 +103,7 @@ public final class MockReturningNonParameterizedAsyncMethod<ReturnValue> {
     /// - Returns: A value, if ``implementation-swift.property`` returns a
     ///   value.
     private func invoke() async -> ReturnValue {
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount += 1
         }
 
@@ -125,7 +125,7 @@ public final class MockReturningNonParameterizedAsyncMethod<ReturnValue> {
         self._implementation.withLockUnchecked { implementation in
             implementation = .unimplemented
         }
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount = .zero
         }
         self._returnedValues.withLockUnchecked { returnedValues in

--- a/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningNonParameterizedAsyncThrowingMethod/MockReturningNonParameterizedAsyncThrowingMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningNonParameterizedAsyncThrowingMethod/MockReturningNonParameterizedAsyncThrowingMethod.swift
@@ -18,7 +18,7 @@ public final class MockReturningNonParameterizedAsyncThrowingMethod<ReturnValue>
     public var implementation: Implementation = .unimplemented
 
     /// The number of times the method has been called.
-    @Locked(.unchecked)
+    @Locked(.checked)
     public private(set) var callCount: Int = .zero
 
     /// All the values that have been returned by the method.
@@ -105,7 +105,7 @@ public final class MockReturningNonParameterizedAsyncThrowingMethod<ReturnValue>
     /// - Returns: A value, if ``implementation-swift.property`` returns a
     ///   value.
     private func invoke() async throws -> ReturnValue {
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount += 1
         }
 
@@ -131,7 +131,7 @@ public final class MockReturningNonParameterizedAsyncThrowingMethod<ReturnValue>
         self._implementation.withLockUnchecked { implementation in
             implementation = .unimplemented
         }
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount = .zero
         }
         self._returnedValues.withLockUnchecked { returnedValues in

--- a/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningNonParameterizedMethod/MockReturningNonParameterizedMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningNonParameterizedMethod/MockReturningNonParameterizedMethod.swift
@@ -18,7 +18,7 @@ public final class MockReturningNonParameterizedMethod<ReturnValue> {
     public var implementation: Implementation = .unimplemented
 
     /// The number of times the method has been called.
-    @Locked(.unchecked)
+    @Locked(.checked)
     public private(set) var callCount: Int = .zero
 
     /// All the values that have been returned by the method.
@@ -101,7 +101,7 @@ public final class MockReturningNonParameterizedMethod<ReturnValue> {
     /// - Returns: A value, if ``implementation-swift.property`` returns a
     ///   value.
     private func invoke() -> ReturnValue {
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount += 1
         }
 
@@ -123,7 +123,7 @@ public final class MockReturningNonParameterizedMethod<ReturnValue> {
         self._implementation.withLockUnchecked { implementation in
             implementation = .unimplemented
         }
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount = .zero
         }
         self._returnedValues.withLockUnchecked { returnedValues in

--- a/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningNonParameterizedThrowingMethod/MockReturningNonParameterizedThrowingMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningNonParameterizedThrowingMethod/MockReturningNonParameterizedThrowingMethod.swift
@@ -18,7 +18,7 @@ public final class MockReturningNonParameterizedThrowingMethod<ReturnValue> {
     public var implementation: Implementation = .unimplemented
 
     /// The number of times the method has been called.
-    @Locked(.unchecked)
+    @Locked(.checked)
     public private(set) var callCount: Int = .zero
 
     /// All the values that have been returned by the method.
@@ -105,7 +105,7 @@ public final class MockReturningNonParameterizedThrowingMethod<ReturnValue> {
     /// - Returns: A value, if ``implementation-swift.property`` returns a
     ///   value.
     private func invoke() throws -> ReturnValue {
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount += 1
         }
 
@@ -131,7 +131,7 @@ public final class MockReturningNonParameterizedThrowingMethod<ReturnValue> {
         self._implementation.withLockUnchecked { implementation in
             implementation = .unimplemented
         }
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount = .zero
         }
         self._returnedValues.withLockUnchecked { returnedValues in

--- a/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningParameterizedAsyncMethod/MockReturningParameterizedAsyncMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningParameterizedAsyncMethod/MockReturningParameterizedAsyncMethod.swift
@@ -31,7 +31,7 @@ public final class MockReturningParameterizedAsyncMethod<
     public var implementation: Implementation = .unimplemented
 
     /// The number of times the method has been called.
-    @Locked(.unchecked)
+    @Locked(.checked)
     public private(set) var callCount: Int = .zero
 
     /// All the arguments with which the method has been invoked.
@@ -140,7 +140,7 @@ public final class MockReturningParameterizedAsyncMethod<
     /// - Parameter arguments: The arguments with which the method is being
     ///   invoked.
     private func recordInput(arguments: Arguments) {
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount += 1
         }
         self._invocations.withLockUnchecked { invocations in
@@ -176,7 +176,7 @@ public final class MockReturningParameterizedAsyncMethod<
         self._implementation.withLockUnchecked { implementation in
             implementation = .unimplemented
         }
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount = .zero
         }
         self._invocations.withLockUnchecked { invocations in

--- a/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningParameterizedAsyncThrowingMethod/MockReturningParameterizedAsyncThrowingMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningParameterizedAsyncThrowingMethod/MockReturningParameterizedAsyncThrowingMethod.swift
@@ -34,7 +34,7 @@ public final class MockReturningParameterizedAsyncThrowingMethod<
     public var implementation: Implementation = .unimplemented
 
     /// The number of times the method has been called.
-    @Locked(.unchecked)
+    @Locked(.checked)
     public private(set) var callCount: Int = .zero
 
     /// All the arguments with which the method has been invoked.
@@ -148,7 +148,7 @@ public final class MockReturningParameterizedAsyncThrowingMethod<
     /// - Parameter arguments: The arguments with which the method is being
     ///   invoked.
     private func recordInput(arguments: Arguments) {
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount += 1
         }
         self._invocations.withLockUnchecked { invocations in
@@ -184,7 +184,7 @@ public final class MockReturningParameterizedAsyncThrowingMethod<
         self._implementation.withLockUnchecked { implementation in
             implementation = .unimplemented
         }
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount = .zero
         }
         self._invocations.withLockUnchecked { invocations in

--- a/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningParameterizedMethod/MockReturningParameterizedMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningParameterizedMethod/MockReturningParameterizedMethod.swift
@@ -31,7 +31,7 @@ public final class MockReturningParameterizedMethod<
     public var implementation: Implementation = .unimplemented
 
     /// The number of times the method has been called.
-    @Locked(.unchecked)
+    @Locked(.checked)
     public private(set) var callCount: Int = .zero
 
     /// All the arguments with which the method has been invoked.
@@ -140,7 +140,7 @@ public final class MockReturningParameterizedMethod<
     /// - Parameter arguments: The arguments with which the method is being
     ///   invoked.
     private func recordInput(arguments: Arguments) {
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount += 1
         }
         self._invocations.withLockUnchecked { invocations in
@@ -176,7 +176,7 @@ public final class MockReturningParameterizedMethod<
         self._implementation.withLockUnchecked { implementation in
             implementation = .unimplemented
         }
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount = .zero
         }
         self._invocations.withLockUnchecked { invocations in

--- a/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningParameterizedThrowingMethod/MockReturningParameterizedThrowingMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningParameterizedThrowingMethod/MockReturningParameterizedThrowingMethod.swift
@@ -34,7 +34,7 @@ public final class MockReturningParameterizedThrowingMethod<
     public var implementation: Implementation = .unimplemented
 
     /// The number of times the method has been called.
-    @Locked(.unchecked)
+    @Locked(.checked)
     public private(set) var callCount: Int = .zero
 
     /// All the arguments with which the method has been invoked.
@@ -147,7 +147,7 @@ public final class MockReturningParameterizedThrowingMethod<
     /// - Parameter arguments: The arguments with which the method is being
     ///   invoked.
     private func recordInput(arguments: Arguments) {
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount += 1
         }
         self._invocations.withLockUnchecked { invocations in
@@ -183,7 +183,7 @@ public final class MockReturningParameterizedThrowingMethod<
         self._implementation.withLockUnchecked { implementation in
             implementation = .unimplemented
         }
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount = .zero
         }
         self._invocations.withLockUnchecked { invocations in

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidNonParameterizedAsyncMethod/MockVoidNonParameterizedAsyncMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidNonParameterizedAsyncMethod/MockVoidNonParameterizedAsyncMethod.swift
@@ -18,7 +18,7 @@ public final class MockVoidNonParameterizedAsyncMethod: Sendable {
     public var implementation: Implementation = .unimplemented
 
     /// The number of times the method has been called.
-    @Locked(.unchecked)
+    @Locked(.checked)
     public private(set) var callCount: Int = .zero
 
     // MARK: Initializers
@@ -68,7 +68,7 @@ public final class MockVoidNonParameterizedAsyncMethod: Sendable {
     /// Records the invocation of the method and invokes
     /// ``implementation-swift.property``.
     private func invoke() async {
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount += 1
         }
         await self.implementation()
@@ -81,7 +81,7 @@ public final class MockVoidNonParameterizedAsyncMethod: Sendable {
         self._implementation.withLockUnchecked { implementation in
             implementation = .unimplemented
         }
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount = .zero
         }
     }

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidNonParameterizedAsyncThrowingMethod/MockVoidNonParameterizedAsyncThrowingMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidNonParameterizedAsyncThrowingMethod/MockVoidNonParameterizedAsyncThrowingMethod.swift
@@ -18,11 +18,11 @@ public final class MockVoidNonParameterizedAsyncThrowingMethod: Sendable {
     public var implementation: Implementation = .unimplemented
 
     /// The number of times the method has been called.
-    @Locked(.unchecked)
+    @Locked(.checked)
     public private(set) var callCount: Int = .zero
 
     /// All the errors that have been thrown by the method.
-    @Locked(.unchecked)
+    @Locked(.checked)
     public private(set) var thrownErrors: [any Error] = []
 
     /// The last error thrown by the method.
@@ -78,14 +78,14 @@ public final class MockVoidNonParameterizedAsyncThrowingMethod: Sendable {
     /// Records the invocation of the method and invokes
     /// ``implementation-swift.property``.
     private func invoke() async throws {
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount += 1
         }
 
         do {
             try await self.implementation()
         } catch {
-            self._thrownErrors.withLockUnchecked { thrownErrors in
+            self._thrownErrors.withLock { thrownErrors in
                 thrownErrors.append(error)
             }
             throw error
@@ -99,10 +99,10 @@ public final class MockVoidNonParameterizedAsyncThrowingMethod: Sendable {
         self._implementation.withLockUnchecked { implementation in
             implementation = .unimplemented
         }
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount = .zero
         }
-        self._thrownErrors.withLockUnchecked { thrownErrors in
+        self._thrownErrors.withLock { thrownErrors in
             thrownErrors.removeAll()
         }
     }

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidNonParameterizedMethod/MockVoidNonParameterizedMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidNonParameterizedMethod/MockVoidNonParameterizedMethod.swift
@@ -18,7 +18,7 @@ public final class MockVoidNonParameterizedMethod: Sendable {
     public var implementation: Implementation = .unimplemented
 
     /// The number of times the method has been called.
-    @Locked(.unchecked)
+    @Locked(.checked)
     public private(set) var callCount: Int = .zero
 
     // MARK: Initializers
@@ -67,7 +67,7 @@ public final class MockVoidNonParameterizedMethod: Sendable {
     /// Records the invocation of the method and invokes
     /// ``implementation-swift.property``.
     private func invoke() {
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount += 1
         }
         self.implementation()
@@ -80,7 +80,7 @@ public final class MockVoidNonParameterizedMethod: Sendable {
         self._implementation.withLockUnchecked { implementation in
             implementation = .unimplemented
         }
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount = .zero
         }
     }

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidNonParameterizedThrowingMethod/MockVoidNonParameterizedThrowingMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidNonParameterizedThrowingMethod/MockVoidNonParameterizedThrowingMethod.swift
@@ -18,11 +18,11 @@ public final class MockVoidNonParameterizedThrowingMethod: Sendable {
     public var implementation: Implementation = .unimplemented
 
     /// The number of times the method has been called.
-    @Locked(.unchecked)
+    @Locked(.checked)
     public private(set) var callCount: Int = .zero
 
     /// All the errors that have been thrown by the method.
-    @Locked(.unchecked)
+    @Locked(.checked)
     public private(set) var thrownErrors: [any Error] = []
 
     /// The last error thrown by the method.
@@ -76,14 +76,14 @@ public final class MockVoidNonParameterizedThrowingMethod: Sendable {
     /// Records the invocation of the method and invokes
     /// ``implementation-swift.property``.
     private func invoke() throws {
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount += 1
         }
 
         do {
             try self.implementation()
         } catch {
-            self._thrownErrors.withLockUnchecked { thrownErrors in
+            self._thrownErrors.withLock { thrownErrors in
                 thrownErrors.append(error)
             }
             throw error
@@ -97,10 +97,10 @@ public final class MockVoidNonParameterizedThrowingMethod: Sendable {
         self._implementation.withLockUnchecked { implementation in
             implementation = .unimplemented
         }
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount = .zero
         }
-        self._thrownErrors.withLockUnchecked { thrownErrors in
+        self._thrownErrors.withLock { thrownErrors in
             thrownErrors.removeAll()
         }
     }

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedAsyncMethod/MockVoidParameterizedAsyncMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedAsyncMethod/MockVoidParameterizedAsyncMethod.swift
@@ -28,7 +28,7 @@ public final class MockVoidParameterizedAsyncMethod<
     public var implementation: Implementation = .unimplemented
 
     /// The number of times the method has been called.
-    @Locked(.unchecked)
+    @Locked(.checked)
     public private(set) var callCount: Int = .zero
 
     /// All the arguments with which the method has been invoked.
@@ -101,7 +101,7 @@ public final class MockVoidParameterizedAsyncMethod<
     /// - Parameter arguments: The arguments with which the method is being
     ///   invoked.
     private func recordInput(arguments: Arguments) {
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount += 1
         }
         self._invocations.withLockUnchecked { invocations in
@@ -125,7 +125,7 @@ public final class MockVoidParameterizedAsyncMethod<
         self._implementation.withLockUnchecked { implementation in
             implementation = .unimplemented
         }
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount = .zero
         }
         self._invocations.withLockUnchecked { invocations in

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedAsyncThrowingMethod/MockVoidParameterizedAsyncThrowingMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedAsyncThrowingMethod/MockVoidParameterizedAsyncThrowingMethod.swift
@@ -31,7 +31,7 @@ public final class MockVoidParameterizedAsyncThrowingMethod<
     public var implementation: Implementation = .unimplemented
 
     /// The number of times the method has been called.
-    @Locked(.unchecked)
+    @Locked(.checked)
     public private(set) var callCount: Int = .zero
 
     /// All the arguments with which the method has been invoked.
@@ -44,7 +44,7 @@ public final class MockVoidParameterizedAsyncThrowingMethod<
     }
 
     /// All the errors that have been thrown by the method.
-    @Locked(.unchecked)
+    @Locked(.checked)
     public private(set) var thrownErrors: [Error] = []
 
     /// The last error thrown by the method.
@@ -120,7 +120,7 @@ public final class MockVoidParameterizedAsyncThrowingMethod<
     /// - Parameter arguments: The arguments with which the method is being
     ///   invoked.
     private func recordInput(arguments: Arguments) {
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount += 1
         }
         self._invocations.withLockUnchecked { invocations in
@@ -141,7 +141,7 @@ public final class MockVoidParameterizedAsyncThrowingMethod<
     ///
     /// - Parameter error: The error thrown by the method.
     private func recordOutput(error: Error) {
-        self._thrownErrors.withLockUnchecked { thrownErrors in
+        self._thrownErrors.withLock { thrownErrors in
             thrownErrors.append(error)
         }
     }
@@ -153,13 +153,13 @@ public final class MockVoidParameterizedAsyncThrowingMethod<
         self._implementation.withLockUnchecked { implementation in
             implementation = .unimplemented
         }
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount = .zero
         }
         self._invocations.withLockUnchecked { invocations in
             invocations.removeAll()
         }
-        self._thrownErrors.withLockUnchecked { thrownErrors in
+        self._thrownErrors.withLock { thrownErrors in
             thrownErrors.removeAll()
         }
     }

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedMethod/MockVoidParameterizedMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedMethod/MockVoidParameterizedMethod.swift
@@ -28,7 +28,7 @@ public final class MockVoidParameterizedMethod<
     public var implementation: Implementation = .unimplemented
 
     /// The number of times the method has been called.
-    @Locked(.unchecked)
+    @Locked(.checked)
     public private(set) var callCount: Int = .zero
 
     /// All the arguments with which the method has been invoked.
@@ -101,7 +101,7 @@ public final class MockVoidParameterizedMethod<
     /// - Parameter arguments: The arguments with which the method is being
     ///   invoked.
     private func recordInput(arguments: Arguments) {
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount += 1
         }
         self._invocations.withLockUnchecked { invocations in
@@ -125,7 +125,7 @@ public final class MockVoidParameterizedMethod<
         self._implementation.withLockUnchecked { implementation in
             implementation = .unimplemented
         }
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount = .zero
         }
         self._invocations.withLockUnchecked { invocations in

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedThrowingMethod/MockVoidParameterizedThrowingMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedThrowingMethod/MockVoidParameterizedThrowingMethod.swift
@@ -31,7 +31,7 @@ public final class MockVoidParameterizedThrowingMethod<
     public var implementation: Implementation = .unimplemented
 
     /// The number of times the method has been called.
-    @Locked(.unchecked)
+    @Locked(.checked)
     public private(set) var callCount: Int = .zero
 
     /// All the arguments with which the method has been invoked.
@@ -44,7 +44,7 @@ public final class MockVoidParameterizedThrowingMethod<
     }
 
     /// All the errors that have been thrown by the method.
-    @Locked(.unchecked)
+    @Locked(.checked)
     public private(set) var thrownErrors: [Error] = []
 
     /// The last error thrown by the method.
@@ -120,7 +120,7 @@ public final class MockVoidParameterizedThrowingMethod<
     /// - Parameter arguments: The arguments with which the method is being
     ///   invoked.
     private func recordInput(arguments: Arguments) {
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount += 1
         }
         self._invocations.withLockUnchecked { invocations in
@@ -141,7 +141,7 @@ public final class MockVoidParameterizedThrowingMethod<
     ///
     /// - Parameter error: The error thrown by the method.
     private func recordOutput(error: Error) {
-        self._thrownErrors.withLockUnchecked { thrownErrors in
+        self._thrownErrors.withLock { thrownErrors in
             thrownErrors.append(error)
         }
     }
@@ -153,13 +153,13 @@ public final class MockVoidParameterizedThrowingMethod<
         self._implementation.withLockUnchecked { implementation in
             implementation = .unimplemented
         }
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount = .zero
         }
         self._invocations.withLockUnchecked { invocations in
             invocations.removeAll()
         }
-        self._thrownErrors.withLockUnchecked { thrownErrors in
+        self._thrownErrors.withLock { thrownErrors in
             thrownErrors.removeAll()
         }
     }

--- a/Sources/Mocking/Models/MockProperties/MockAccessors/MockPropertyAsyncGetter/MockPropertyAsyncGetter.swift
+++ b/Sources/Mocking/Models/MockProperties/MockAccessors/MockPropertyAsyncGetter/MockPropertyAsyncGetter.swift
@@ -18,7 +18,7 @@ public final class MockPropertyAsyncGetter<Value> {
     public var implementation: Implementation = .unimplemented
 
     /// The number of times the getter has been called.
-    @Locked(.unchecked)
+    @Locked(.checked)
     public private(set) var callCount: Int = .zero
 
     /// All the values that have been returned by the getter.
@@ -56,7 +56,7 @@ public final class MockPropertyAsyncGetter<Value> {
     /// - Returns: A value, if ``implementation-swift.property`` returns a
     ///   value.
     func get() async -> Value {
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount += 1
         }
 
@@ -78,7 +78,7 @@ public final class MockPropertyAsyncGetter<Value> {
         self._implementation.withLockUnchecked { implementation in
             implementation = .unimplemented
         }
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount = .zero
         }
         self._returnedValues.withLockUnchecked { returnedValues in

--- a/Sources/Mocking/Models/MockProperties/MockAccessors/MockPropertyAsyncThrowingGetter/MockPropertyAsyncThrowingGetter.swift
+++ b/Sources/Mocking/Models/MockProperties/MockAccessors/MockPropertyAsyncThrowingGetter/MockPropertyAsyncThrowingGetter.swift
@@ -18,7 +18,7 @@ public final class MockPropertyAsyncThrowingGetter<Value> {
     public var implementation: Implementation = .unimplemented
 
     /// The number of times the getter has been called.
-    @Locked(.unchecked)
+    @Locked(.checked)
     public private(set) var callCount: Int = .zero
 
     /// All the values that have been returned by the getter.
@@ -58,7 +58,7 @@ public final class MockPropertyAsyncThrowingGetter<Value> {
     /// - Returns: A value, if ``implementation-swift.property`` returns a
     ///   value.
     func get() async throws -> Value {
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount += 1
         }
 
@@ -84,7 +84,7 @@ public final class MockPropertyAsyncThrowingGetter<Value> {
         self._implementation.withLockUnchecked { implementation in
             implementation = .unimplemented
         }
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount = .zero
         }
         self._returnedValues.withLockUnchecked { returnedValues in

--- a/Sources/Mocking/Models/MockProperties/MockAccessors/MockPropertyGetter/MockPropertyGetter.swift
+++ b/Sources/Mocking/Models/MockProperties/MockAccessors/MockPropertyGetter/MockPropertyGetter.swift
@@ -18,7 +18,7 @@ public final class MockPropertyGetter<Value> {
     public var implementation: Implementation = .unimplemented
 
     /// The number of times the getter has been called.
-    @Locked(.unchecked)
+    @Locked(.checked)
     public private(set) var callCount: Int = .zero
 
     /// All the values that have been returned by the getter.
@@ -56,7 +56,7 @@ public final class MockPropertyGetter<Value> {
     /// - Returns: A value, if ``implementation-swift.property`` returns a
     ///   value.
     func get() -> Value {
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount += 1
         }
 
@@ -78,7 +78,7 @@ public final class MockPropertyGetter<Value> {
         self._implementation.withLockUnchecked { implementation in
             implementation = .unimplemented
         }
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount = .zero
         }
         self._returnedValues.withLockUnchecked { returnedValues in

--- a/Sources/Mocking/Models/MockProperties/MockAccessors/MockPropertySetter/MockPropertySetter.swift
+++ b/Sources/Mocking/Models/MockProperties/MockAccessors/MockPropertySetter/MockPropertySetter.swift
@@ -18,7 +18,7 @@ public final class MockPropertySetter<Value> {
     public var implementation: Implementation = .unimplemented
 
     /// The number of times the setter has been called.
-    @Locked(.unchecked)
+    @Locked(.checked)
     public private(set) var callCount: Int = .zero
 
     /// All the values with which the setter has been invoked.
@@ -37,7 +37,7 @@ public final class MockPropertySetter<Value> {
     ///
     /// - Parameter value: The value with which the setter is being invoked.
     func set(_ value: Value) {
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount += 1
         }
         self._invocations.withLockUnchecked { invocations in
@@ -53,7 +53,7 @@ public final class MockPropertySetter<Value> {
         self._implementation.withLockUnchecked { implementation in
             implementation = .unimplemented
         }
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount = .zero
         }
         self._invocations.withLockUnchecked { invocations in

--- a/Sources/Mocking/Models/MockProperties/MockAccessors/MockPropertyThrowingGetter/MockPropertyThrowingGetter.swift
+++ b/Sources/Mocking/Models/MockProperties/MockAccessors/MockPropertyThrowingGetter/MockPropertyThrowingGetter.swift
@@ -18,7 +18,7 @@ public final class MockPropertyThrowingGetter<Value> {
     public var implementation: Implementation = .unimplemented
 
     /// The number of times the getter has been called.
-    @Locked(.unchecked)
+    @Locked(.checked)
     public private(set) var callCount: Int = .zero
 
     /// All the values that have been returned by the getter.
@@ -58,7 +58,7 @@ public final class MockPropertyThrowingGetter<Value> {
     /// - Returns: A value, if ``implementation-swift.property`` returns a
     ///   value.
     func get() throws -> Value {
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount += 1
         }
 
@@ -84,7 +84,7 @@ public final class MockPropertyThrowingGetter<Value> {
         self._implementation.withLockUnchecked { implementation in
             implementation = .unimplemented
         }
-        self._callCount.withLockUnchecked { callCount in
+        self._callCount.withLock { callCount in
             callCount = .zero
         }
         self._returnedValues.withLockUnchecked { returnedValues in


### PR DESCRIPTION
## 📝 Summary

<!-- 
Please provide a brief summary of your changes along with any relevant context.
Include any screenshots, logs, or terminal output you think would be helpful to reviewers.
-->

- Updated `callCount` and `thrownErrors` properties to use checked locks since `Int` and `Error` are both `Sendable`. 

## 🛠️ Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds functionality)
- [ ] Breaking change (bug fix or feature that is not backwards compatible)
- [ ] Documentation (DocC, API docs, markdown files, templates, etc.)
- [ ] Testing (new tests, updated tests, etc.)
- [ ] Refactoring or code formatting (no logic changes)
- [ ] Updating dependencies (Swift packages, Homebrew, etc.)
- [ ] CI/CD (change to automated workflows)
- [x] Chore (other maintenance)

## 🧪 How Has This Been Tested?

<!-- 
Please describe the tests you've run to verify your changes.
If fixing a bug, please describe the steps to reproduce the bug.
Include any screenshots, logs, or terminal output you think would be helpful to reviewers.
-->

- Existing tests all pass.

## 🔗 Related PRs or Issues <!-- Delete section if not applicable -->

- Resolves #124.

## ✅ Checklist

<!-- Confirm that you've completed the following steps. -->

- [x] I have added relevant tests
- [x] I have verified all tests pass
- [x] I have formatted my code using `SwiftFormat`
- [x] I have updated documentation (if needed)
- [x] I have added the appropriate label to my PR
- [x] I have read the [contributing guidelines](https://github.com/fetch-rewards/swift-mocking/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/fetch-rewards/swift-mocking/blob/main/CODE_OF_CONDUCT.md)