### PR TITLE
Fix 'Package import was not used in package declarations' warning

### DIFF
--- a/Sources/Mocking/Macros/Mocked.swift
+++ b/Sources/Mocking/Macros/Mocked.swift
@@ -21,7 +21,7 @@
 ///     `#if` compiler directive used to wrap the generated mock.
 ///   - sendableConformance: The `Sendable` conformance to apply to
 ///     the generated mock.
-@attached(peer, names: suffixed(Mock))
+@attached(peer, names: suffixed(Mock), prefixed(_noOp))
 public macro Mocked(
     compilationCondition: MockCompilationCondition = .swiftMockingEnabled,
     sendableConformance: MockSendableConformance = .checked

--- a/Sources/Mocking/Models/_MockingModule.swift
+++ b/Sources/Mocking/Models/_MockingModule.swift
@@ -1,0 +1,16 @@
+//
+//  _MockingModule.swift
+//
+//  Copyright © 2025 Fetch.
+//
+
+/// A marker type used in generated mock code to ensure package imports
+/// are recognized as used by the compiler.
+///
+/// This type exists to work around a Swift compiler limitation where
+/// `package import` statements may be incorrectly flagged as unused when
+/// the imported module's types are only referenced in macro-generated code.
+///
+/// - SeeAlso: [Swift Forums Discussion](https://forums.swift.org/t/internal-imports-by-default-is-very-problematic-for-generated-code/82722/4)
+/// - SeeAlso: [SE-0409: Access Level on Imports](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md)
+public enum _MockingModule: Sendable {}

--- a/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
+++ b/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
@@ -23,6 +23,43 @@ public struct MockedMacro: PeerMacro {
         }
 
         let macroArguments = MacroArguments(node: node)
+        let accessLevel = protocolDeclaration.minimumConformingAccessLevel
+
+        // Only generate the _noOp variable for package access level to work around
+        // the "package import was not used in package declarations" warning
+        let noOpDeclaration: DeclSyntax? = if accessLevel == .package {
+            DeclSyntax(
+                VariableDeclSyntax(
+                    modifiers: DeclModifierListSyntax {
+                        accessLevel.modifier
+                    },
+                    bindingSpecifier: .keyword(.let),
+                    bindings: PatternBindingListSyntax {
+                        PatternBindingSyntax(
+                            pattern: IdentifierPatternSyntax(
+                                identifier: "_noOp\(protocolDeclaration.name.trimmed)"
+                            ),
+                            typeAnnotation: TypeAnnotationSyntax(
+                                type: MetatypeTypeSyntax(
+                                    baseType: IdentifierTypeSyntax(name: "_MockingModule"),
+                                    metatypeSpecifier: .keyword(.Type)
+                                )
+                            ),
+                            initializer: InitializerClauseSyntax(
+                                value: MemberAccessExprSyntax(
+                                    base: DeclReferenceExprSyntax(baseName: "_MockingModule"),
+                                    period: .periodToken(),
+                                    name: "self"
+                                )
+                            )
+                        )
+                    }
+                )
+            )
+        } else {
+            nil
+        }
+
         let mockDeclaration = DeclSyntax(
             ClassDeclSyntax(
                 attributes: AttributeListSyntax {
@@ -52,7 +89,11 @@ public struct MockedMacro: PeerMacro {
         )
 
         guard let compilationCondition = macroArguments.compilationCondition.rawValue else {
-            return [mockDeclaration]
+            if let noOpDeclaration {
+                return [noOpDeclaration, mockDeclaration]
+            } else {
+                return [mockDeclaration]
+            }
         }
 
         let ifConfigDeclaration = IfConfigDeclSyntax(
@@ -64,6 +105,9 @@ public struct MockedMacro: PeerMacro {
                     ),
                     elements: .statements(
                         CodeBlockItemListSyntax {
+                            if let noOpDeclaration {
+                                CodeBlockItemSyntax(item: .decl(noOpDeclaration))
+                            }
                             CodeBlockItemSyntax(item: .decl(mockDeclaration))
                         }
                     )

--- a/Tests/MockingMacrosTests/Macros/MockedMacro/Mocked_AccessLevelTests.swift
+++ b/Tests/MockingMacrosTests/Macros/MockedMacro/Mocked_AccessLevelTests.swift
@@ -23,7 +23,7 @@ struct Mocked_AccessLevelTests {
             """,
             generates: """
             #if SWIFT_MOCKING_ENABLED
-            @MockedMembers
+            \(mock.noOpDeclaration)@MockedMembers
             \(mock.modifiers)class DependencyMock: Dependency {
             }
             #endif

--- a/Tests/MockingMacrosTests/Macros/MockedMacro/Mocked_AssociatedTypeTests.swift
+++ b/Tests/MockingMacrosTests/Macros/MockedMacro/Mocked_AssociatedTypeTests.swift
@@ -26,7 +26,7 @@ struct Mocked_AssociatedTypeTests {
             """,
             generates: """
             #if SWIFT_MOCKING_ENABLED
-            @MockedMembers
+            \(mock.noOpDeclaration)@MockedMembers
             \(mock.modifiers)\
             class DependencyMock<A: Hashable, B: Identifiable>: Dependency {
             }
@@ -49,7 +49,7 @@ struct Mocked_AssociatedTypeTests {
             """,
             generates: """
             #if SWIFT_MOCKING_ENABLED
-            @MockedMembers
+            \(mock.noOpDeclaration)@MockedMembers
             \(mock.modifiers)\
             class DependencyMock<\
             A: Hashable & Identifiable, \
@@ -75,7 +75,7 @@ struct Mocked_AssociatedTypeTests {
             """,
             generates: """
             #if SWIFT_MOCKING_ENABLED
-            @MockedMembers
+            \(mock.noOpDeclaration)@MockedMembers
             \(mock.modifiers)\
             class DependencyMock<\
             A: Hashable & Identifiable, \
@@ -95,12 +95,12 @@ struct Mocked_AssociatedTypeTests {
         assertMocked(
             """
             \(interface.accessLevel) protocol Dependency {
-                associatedtype A: Sendable, Hashable & Identifiable 
+                associatedtype A: Sendable, Hashable & Identifiable
             }
             """,
             generates: """
             #if SWIFT_MOCKING_ENABLED
-            @MockedMembers
+            \(mock.noOpDeclaration)@MockedMembers
             \(mock.modifiers)\
             class DependencyMock<\
             A: Sendable & Hashable & Identifiable\
@@ -123,13 +123,13 @@ struct Mocked_AssociatedTypeTests {
             \(interface.accessLevel) protocol Dependency<A> where A: Hashable {
                 associatedtype A: Comparable
                 associatedtype B: BidirectionalCollection \
-                where B.Element: Equatable, B.Element: Identifiable
+            where B.Element: Equatable, B.Element: Identifiable
                 associatedtype C: RandomAccessCollection where C.Element == String
             }
             """,
             generates: """
             #if SWIFT_MOCKING_ENABLED
-            @MockedMembers
+            \(mock.noOpDeclaration)@MockedMembers
             \(mock.modifiers)\
             class DependencyMock<\
             A: Comparable, \

--- a/Tests/MockingMacrosTests/Macros/MockedMacro/Mocked_CompilationConditionTests.swift
+++ b/Tests/MockingMacrosTests/Macros/MockedMacro/Mocked_CompilationConditionTests.swift
@@ -24,7 +24,7 @@ struct Mocked_CompilationConditionTests {
             compilationCondition: nil,
             generates: """
             #if SWIFT_MOCKING_ENABLED
-            @MockedMembers
+            \(mock.noOpDeclaration)@MockedMembers
             \(mock.modifiers)\
             class DependencyMock: Dependency {
             }
@@ -44,7 +44,7 @@ struct Mocked_CompilationConditionTests {
             """,
             compilationCondition: ".none",
             generates: """
-            @MockedMembers
+            \(mock.noOpDeclarationUnwrapped)@MockedMembers
             \(mock.modifiers)\
             class DependencyMock: Dependency {
             }
@@ -64,7 +64,7 @@ struct Mocked_CompilationConditionTests {
             compilationCondition: ".debug",
             generates: """
             #if DEBUG
-            @MockedMembers
+            \(mock.noOpDeclaration)@MockedMembers
             \(mock.modifiers)\
             class DependencyMock: Dependency {
             }
@@ -85,7 +85,7 @@ struct Mocked_CompilationConditionTests {
             compilationCondition: ".swiftMockingEnabled",
             generates: """
             #if SWIFT_MOCKING_ENABLED
-            @MockedMembers
+            \(mock.noOpDeclaration)@MockedMembers
             \(mock.modifiers)\
             class DependencyMock: Dependency {
             }
@@ -106,7 +106,7 @@ struct Mocked_CompilationConditionTests {
             compilationCondition: #".custom("!RELEASE")"#,
             generates: """
             #if !RELEASE
-            @MockedMembers
+            \(mock.noOpDeclaration)@MockedMembers
             \(mock.modifiers)\
             class DependencyMock: Dependency {
             }
@@ -127,7 +127,7 @@ struct Mocked_CompilationConditionTests {
             compilationCondition: #""!RELEASE""#,
             generates: """
             #if !RELEASE
-            @MockedMembers
+            \(mock.noOpDeclaration)@MockedMembers
             \(mock.modifiers)\
             class DependencyMock: Dependency {
             }

--- a/Tests/MockingMacrosTests/Macros/MockedMacro/Mocked_InheritanceTests.swift
+++ b/Tests/MockingMacrosTests/Macros/MockedMacro/Mocked_InheritanceTests.swift
@@ -23,7 +23,7 @@ struct Mocked_InheritanceTests {
             """,
             generates: """
             #if SWIFT_MOCKING_ENABLED
-            @MockedMembers
+            \(mock.noOpDeclaration)@MockedMembers
             \(mock.modifiers)class DependencyMock: Dependency {
             }
             #endif
@@ -44,7 +44,7 @@ struct Mocked_InheritanceTests {
             """,
             generates: """
             #if SWIFT_MOCKING_ENABLED
-            @MockedMembers
+            \(mock.noOpDeclaration)@MockedMembers
             \(mock.modifiers)actor DependencyMock: Dependency {
             }
             #endif
@@ -65,7 +65,7 @@ struct Mocked_InheritanceTests {
             """,
             generates: """
             #if SWIFT_MOCKING_ENABLED
-            @MockedMembers
+            \(mock.noOpDeclaration)@MockedMembers
             \(mock.modifiers)class DependencyMock: Dependency {
             }
             #endif
@@ -86,7 +86,7 @@ struct Mocked_InheritanceTests {
             """,
             generates: """
             #if SWIFT_MOCKING_ENABLED
-            @MockedMembers
+            \(mock.noOpDeclaration)@MockedMembers
             \(mock.modifiers)actor DependencyMock: Dependency {
             }
             #endif
@@ -105,7 +105,7 @@ struct Mocked_InheritanceTests {
             """,
             generates: """
             #if SWIFT_MOCKING_ENABLED
-            @MockedMembers
+            \(mock.noOpDeclaration)@MockedMembers
             \(mock.modifiers)actor DependencyMock: Dependency {
             }
             #endif

--- a/Tests/MockingMacrosTests/Macros/MockedMacro/Mocked_InitializerTests.swift
+++ b/Tests/MockingMacrosTests/Macros/MockedMacro/Mocked_InitializerTests.swift
@@ -23,7 +23,7 @@ struct Mocked_InitializerTests {
             """,
             generates: """
             #if SWIFT_MOCKING_ENABLED
-            @MockedMembers
+            \(mock.noOpDeclaration)@MockedMembers
             \(mock.modifiers)class DependencyMock: Dependency {
             }
             #endif
@@ -48,7 +48,7 @@ struct Mocked_InitializerTests {
             """,
             generates: """
             #if SWIFT_MOCKING_ENABLED
-            @MockedMembers
+            \(mock.noOpDeclaration)@MockedMembers
             \(mock.modifiers)class DependencyMock: Dependency {
                 \(mock.memberModifiers)init(parameter: Int) {
                 }

--- a/Tests/MockingMacrosTests/Macros/MockedMacro/Mocked_SendableConformanceTests.swift
+++ b/Tests/MockingMacrosTests/Macros/MockedMacro/Mocked_SendableConformanceTests.swift
@@ -25,7 +25,7 @@ struct Mocked_SendableConformanceTests {
             sendableConformance: nil,
             generates: """
             #if SWIFT_MOCKING_ENABLED
-            @MockedMembers
+            \(mock.noOpDeclaration)@MockedMembers
             \(mock.modifiers)\
             class DependencyMock: Dependency {
             }
@@ -49,7 +49,7 @@ struct Mocked_SendableConformanceTests {
             sendableConformance: ".checked",
             generates: """
             #if SWIFT_MOCKING_ENABLED
-            @MockedMembers
+            \(mock.noOpDeclaration)@MockedMembers
             \(mock.modifiers)\
             class DependencyMock: Dependency {
             }
@@ -73,7 +73,7 @@ struct Mocked_SendableConformanceTests {
             sendableConformance: ".unchecked",
             generates: """
             #if SWIFT_MOCKING_ENABLED
-            @MockedMembers
+            \(mock.noOpDeclaration)@MockedMembers
             \(mock.modifiers)\
             class DependencyMock: @unchecked Sendable, Dependency {
             }
@@ -97,7 +97,7 @@ struct Mocked_SendableConformanceTests {
             sendableConformance: "MockSendableConformance.unchecked",
             generates: """
             #if SWIFT_MOCKING_ENABLED
-            @MockedMembers
+            \(mock.noOpDeclaration)@MockedMembers
             \(mock.modifiers)\
             class DependencyMock: @unchecked Sendable, Dependency {
             }

--- a/Tests/MockingMacrosTests/Macros/MockedMacro/TestHelpers/MockConfiguration.swift
+++ b/Tests/MockingMacrosTests/Macros/MockedMacro/TestHelpers/MockConfiguration.swift
@@ -15,6 +15,22 @@ struct MockConfiguration {
     let modifiers: String
     let memberModifiers: String
 
+    /// Returns the `_noOp` declaration for package access level, or empty string otherwise.
+    var noOpDeclaration: String {
+        if accessLevel == .package {
+            return "package let _noOpDependency: _MockingModule.Type = _MockingModule.self\n"
+        }
+        return ""
+    }
+
+    /// Returns the `_noOp` declaration with trailing newline for no-compilation-condition case.
+    var noOpDeclarationUnwrapped: String {
+        if accessLevel == .package {
+            return "package let _noOpDependency: _MockingModule.Type = _MockingModule.self\n\n"
+        }
+        return ""
+    }
+
     // MARK: Initializers
 
     init(interfaceAccessLevel: AccessLevelSyntax) {


### PR DESCRIPTION
## Summary

This PR fixes the Swift 6 compiler warning "Package import of 'Mocking' was not used in package declarations" that occurs when using `package import Mocking` with the `@Mocked` macro.

### The Problem

With Swift 6's `InternalImportsByDefault` feature, the compiler incorrectly flags package imports as unused when the imported module's types are only referenced in macro-generated code. This is because macro expansions happen after the import usage check.

Related Swift Forums discussion: https://forums.swift.org/t/internal-imports-by-default-is-very-problematic-for-generated-code/82722/4

### The Solution

For protocols with `package` access level, the `@Mocked` macro now generates a top-level variable that explicitly references a type from the Mocking module:

```swift
package let _noOpProtocolName: _MockingModule.Type = _MockingModule.self
```

This ensures the compiler recognizes that the package import is being used in a package declaration.

## Changes

- Added `_MockingModule` marker enum to `Sources/Mocking/Models/`
- Updated `@Mocked` macro to generate `_noOp` variable for package access level only
- Added `prefixed(_noOp)` to the macro's peer names
- Updated all affected tests

## Test plan

- [x] All 204 tests pass
- [x] Verified warning is resolved when using `package import Mocking` in consuming package

🤖 Generated with [Claude Code](https://claude.com/claude-code)