### PR TITLE
Add support for conditionally compiled protocol members

### DIFF
--- a/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
+++ b/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
@@ -141,7 +141,9 @@ extension MockedMacro {
         from protocolDeclaration: ProtocolDeclSyntax
     ) -> GenericParameterClauseSyntax? {
         let memberBlock = protocolDeclaration.memberBlock
-        let associatedTypeDeclarations = self.collectAssociatedTypes(from: memberBlock)
+        let associatedTypeDeclarations = self.associatedTypeDeclarations(
+            from: memberBlock.members
+        )
 
         guard !associatedTypeDeclarations.isEmpty else {
             return nil
@@ -193,53 +195,43 @@ extension MockedMacro {
         }
     }
 
-    /// Collects all associated type declarations from a member block, including
-    /// those inside `#if` blocks.
+    /// Returns the associated type declarations from the provided `members`,
+    /// including those inside `#if` declarations.
     ///
-    /// - Parameter memberBlock: The member block to search.
-    /// - Returns: An array of associated type declarations.
-    private static func collectAssociatedTypes(
-        from memberBlock: MemberBlockSyntax
+    /// - Parameter members: The members to search.
+    /// - Returns: The associated type declarations from the provided `members`.
+    private static func associatedTypeDeclarations(
+        from members: MemberBlockItemListSyntax
     ) -> [AssociatedTypeDeclSyntax] {
-        var associatedTypes: [AssociatedTypeDeclSyntax] = []
-
-        for member in memberBlock.members {
-            if let associatedType = member.decl.as(AssociatedTypeDeclSyntax.self) {
-                associatedTypes.append(associatedType)
-            } else if let ifConfigDecl = member.decl.as(IfConfigDeclSyntax.self) {
-                associatedTypes.append(contentsOf: self.collectAssociatedTypes(from: ifConfigDecl))
+        members.flatMap { member -> [AssociatedTypeDeclSyntax] in
+            if let associatedTypeDeclaration = member.decl.as(AssociatedTypeDeclSyntax.self) {
+                return [associatedTypeDeclaration]
+            } else if let ifConfigDeclaration = member.decl.as(IfConfigDeclSyntax.self) {
+                return self.associatedTypeDeclarations(from: ifConfigDeclaration)
+            } else {
+                return []
             }
         }
-
-        return associatedTypes
     }
 
-    /// Collects all associated type declarations from an `IfConfigDeclSyntax`,
-    /// searching all branches.
+    /// Returns the associated type declarations from the provided
+    /// `ifConfigDeclaration`.
     ///
-    /// - Parameter ifConfigDecl: The `#if` declaration to search.
-    /// - Returns: An array of associated type declarations.
-    private static func collectAssociatedTypes(
-        from ifConfigDecl: IfConfigDeclSyntax
+    /// This method recursively searches nested `#if` declarations.
+    ///
+    /// - Parameter ifConfigDeclaration: The `#if` declaration to search.
+    /// - Returns: The associated type declarations from the provided
+    ///   `ifConfigDeclaration`.
+    private static func associatedTypeDeclarations(
+        from ifConfigDeclaration: IfConfigDeclSyntax
     ) -> [AssociatedTypeDeclSyntax] {
-        var associatedTypes: [AssociatedTypeDeclSyntax] = []
-
-        for clause in ifConfigDecl.clauses {
+        ifConfigDeclaration.clauses.flatMap { clause -> [AssociatedTypeDeclSyntax] in
             guard case let .decls(members) = clause.elements else {
-                continue
+                return []
             }
 
-            for member in members {
-                if let associatedType = member.decl.as(AssociatedTypeDeclSyntax.self) {
-                    associatedTypes.append(associatedType)
-                } else if let nestedIfConfig = member.decl.as(IfConfigDeclSyntax.self) {
-                    associatedTypes
-                        .append(contentsOf: self.collectAssociatedTypes(from: nestedIfConfig))
-                }
-            }
+            return self.associatedTypeDeclarations(from: members)
         }
-
-        return associatedTypes
     }
 
     // MARK: Inheritance Clause

--- a/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
+++ b/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
@@ -23,6 +23,17 @@ public struct MockedMacro: PeerMacro {
         }
 
         let macroArguments = MacroArguments(node: node)
+
+        if let conflictingConditionalClauses = self.conflictingConditionalClauses(
+            from: protocolDeclaration.memberBlock.members
+        ) {
+            return try self.expansionWithConditionalConformance(
+                protocolDeclaration: protocolDeclaration,
+                macroArguments: macroArguments,
+                clauses: conflictingConditionalClauses
+            )
+        }
+
         let mockDeclaration = DeclSyntax(
             ClassDeclSyntax(
                 attributes: AttributeListSyntax {
@@ -133,12 +144,14 @@ extension MockedMacro {
     /// final class DependencyMock<Item: Sendable & Equatable & Identifiable>: Dependency {}
     /// ```
     ///
-    /// - Parameter protocolDeclaration: The protocol to which the mock must
-    ///   conform.
-    /// - Returns: The generic parameter clause to apply to the mock
-    ///   declaration.
+    /// - Parameters:
+    ///   - protocolDeclaration: The protocol to which the mock must conform.
+    ///   - excludingConstraintsFor: Names of associated types whose constraints
+    ///     should be excluded (used for conditional conformance).
+    /// - Returns: The generic parameter clause to apply to the mock declaration.
     private static func mockGenericParameterClause(
-        from protocolDeclaration: ProtocolDeclSyntax
+        from protocolDeclaration: ProtocolDeclSyntax,
+        excludingConstraintsFor excludedNames: Set<String> = []
     ) -> GenericParameterClauseSyntax? {
         let memberBlock = protocolDeclaration.memberBlock
         let associatedTypeDeclarations = self.associatedTypeDeclarations(
@@ -163,8 +176,10 @@ extension MockedMacro {
         return GenericParameterClauseSyntax {
             for associatedTypeDeclaration in uniqueAssociatedTypes {
                 let genericParameterName = associatedTypeDeclaration.name.trimmed
+                let shouldExcludeConstraints = excludedNames.contains(associatedTypeDeclaration.name.text)
 
-                if let inheritanceClause = associatedTypeDeclaration.inheritanceClause {
+                if !shouldExcludeConstraints,
+                   let inheritanceClause = associatedTypeDeclaration.inheritanceClause {
                     let commaSeparatedInheritedTypes = inheritanceClause
                         .inheritedTypes(ofType: IdentifierTypeSyntax.self)
                         .compactMap { CompositionTypeElementSyntax(type: $0) }
@@ -279,18 +294,14 @@ extension MockedMacro {
     private static func mockGenericWhereClause(
         from protocolDeclaration: ProtocolDeclSyntax
     ) -> GenericWhereClauseSyntax? {
-        let genericWhereClauses = protocolDeclaration.genericWhereClauses
-
-        guard !genericWhereClauses.isEmpty else {
+        guard !protocolDeclaration.genericWhereClauses.isEmpty else {
             return nil
         }
 
         return GenericWhereClauseSyntax {
-            for genericWhereClause in genericWhereClauses {
-                for requirement in genericWhereClause.requirements {
-                    requirement.trimmed
-                }
-            }
+            protocolDeclaration.genericWhereClauses
+                .flatMap(\.requirements)
+                .map(\.trimmed)
         }
     }
 
@@ -662,6 +673,227 @@ extension MockedMacro {
 
             for modifier in modifiers where !modifier.isAccessLevel {
                 modifier.trimmed
+            }
+        }
+    }
+}
+
+// MARK: - Conditional Associated Type Conformance
+
+extension MockedMacro {
+
+    /// A tuple representing one clause of an `#if` block containing associated
+    /// types with their conditional compilation condition.
+    ///
+    /// - `condition`: The conditional compilation expression (e.g., `DEBUG`),
+    ///   or `nil` for `#else` clauses.
+    /// - `associatedTypes`: The associated type declarations within this clause.
+    private typealias ConditionalClause = (
+        condition: ExprSyntax?,
+        associatedTypes: [AssociatedTypeDeclSyntax]
+    )
+
+    /// Returns conditional clauses containing associated types with conflicting
+    /// constraints across different `#if` branches.
+    ///
+    /// This method detects when the same associated type has different constraints
+    /// in different conditional compilation branches, requiring conditional conformance.
+    ///
+    /// - Parameter members: The protocol members to search for conflicting
+    ///   conditional associated types.
+    /// - Returns: An array of conditional clauses if conflicts are found, or
+    ///   `nil` if there are no conflicts.
+    private static func conflictingConditionalClauses(
+        from members: MemberBlockItemListSyntax
+    ) -> [ConditionalClause]? {
+        members
+            .compactMap { member in member.decl.as(IfConfigDeclSyntax.self) }
+            .compactMap { ifConfigDeclaration -> [ConditionalClause]? in
+                let clauses = ifConfigDeclaration.clauses.compactMap { clause -> ConditionalClause? in
+                    guard case let .decls(declarations) = clause.elements else { return nil }
+
+                    let associatedTypes = declarations.compactMap { declaration in
+                        declaration.decl.as(AssociatedTypeDeclSyntax.self)
+                    }
+
+                    guard !associatedTypes.isEmpty else { return nil }
+
+                    return (clause.condition, associatedTypes)
+                }
+
+                guard !clauses.isEmpty else { return nil }
+
+                let constraintSetsByTypeName = Dictionary(
+                    grouping: clauses.flatMap(\.associatedTypes),
+                    by: \.name.text
+                ).mapValues { types in
+                    Set(types.map { type in
+                        type.inheritanceClause?.description.trimmingCharacters(in: .whitespaces) ?? ""
+                    })
+                }
+
+                let hasConflictingConstraints = constraintSetsByTypeName.values.contains { constraints in
+                    constraints.count > 1
+                }
+                return hasConflictingConstraints ? clauses : nil
+            }
+            .first
+    }
+
+    /// Returns the macro expansion with conditional conformance extensions
+    /// for protocols with conflicting associated type constraints in `#if` blocks.
+    ///
+    /// This method generates a mock class without associated type constraints,
+    /// along with conditional extensions that conform to the protocol under
+    /// specific compilation conditions with the appropriate constraints applied.
+    ///
+    /// - Parameters:
+    ///   - protocolDeclaration: The protocol to which the mock must conform.
+    ///   - macroArguments: The macro arguments provided to the `@Mocked` attribute.
+    ///   - clauses: The conditional clauses containing conflicting associated
+    ///     type constraints.
+    /// - Returns: The declarations to generate, including the mock class and
+    ///   conditional conformance extensions.
+    private static func expansionWithConditionalConformance(
+        protocolDeclaration: ProtocolDeclSyntax,
+        macroArguments: MacroArguments,
+        clauses: [ConditionalClause]
+    ) throws -> [DeclSyntax] {
+        let mockName = self.mockName(from: protocolDeclaration)
+        let associatedTypeNamesToExclude = Set(clauses.flatMap { clause in
+            clause.associatedTypes.map(\.name.text)
+        })
+
+        let mockDeclaration = ClassDeclSyntax(
+            attributes: AttributeListSyntax {
+                AttributeSyntax(
+                    atSign: .atSignToken(),
+                    attributeName: IdentifierTypeSyntax(name: "MockedMembers"),
+                    trailingTrivia: .newline
+                )
+            },
+            modifiers: self.mockModifiers(from: protocolDeclaration),
+            classKeyword: .keyword(protocolDeclaration.isActorConstrained ? .actor : .class),
+            name: mockName,
+            genericParameterClause: self.mockGenericParameterClause(
+                from: protocolDeclaration,
+                excludingConstraintsFor: associatedTypeNamesToExclude
+            ),
+            inheritanceClause: macroArguments.sendableConformance == .unchecked
+                ? InheritanceClauseSyntax { InheritedTypeSyntax.uncheckedSendable }
+                : nil,
+            genericWhereClause: self.mockGenericWhereClause(from: protocolDeclaration),
+            memberBlock: try self.mockMemberBlock(from: protocolDeclaration)
+        )
+
+        let ifConfigDeclaration = IfConfigDeclSyntax(
+            clauses: IfConfigClauseListSyntax(
+                clauses.enumerated().map { index, clause in
+                    IfConfigClauseSyntax(
+                        poundKeyword: index == 0 ? .poundIfToken()
+                            : clause.condition != nil ? .poundElseifToken() : .poundElseToken(),
+                        condition: clause.condition,
+                        elements: .decls(MemberBlockItemListSyntax {
+                            MemberBlockItemSyntax(decl: ExtensionDeclSyntax(
+                                extendedType: IdentifierTypeSyntax(name: mockName),
+                                inheritanceClause: InheritanceClauseSyntax {
+                                    InheritedTypeSyntax(type: protocolDeclaration.type)
+                                },
+                                genericWhereClause: self.whereClause(from: clause.associatedTypes),
+                                memberBlock: MemberBlockSyntax(members: [])
+                            ))
+                        })
+                    )
+                }
+            )
+        )
+
+        let declarations: [DeclSyntax] = [
+            DeclSyntax(mockDeclaration),
+            DeclSyntax(ifConfigDeclaration)
+        ]
+
+        guard let condition = macroArguments.compilationCondition.rawValue else {
+            return declarations
+        }
+
+        return [DeclSyntax(IfConfigDeclSyntax(clauses: IfConfigClauseListSyntax {
+            IfConfigClauseSyntax(
+                poundKeyword: .poundIfToken(),
+                condition: DeclReferenceExprSyntax(baseName: .identifier(condition)),
+                elements: .statements(CodeBlockItemListSyntax(
+                    declarations.map { declaration in
+                        CodeBlockItemSyntax(item: .decl(declaration))
+                    }
+                ))
+            )
+        }))]
+    }
+
+    /// Builds a generic `where` clause from associated type constraints.
+    ///
+    /// This method extracts all constraints from the provided associated types
+    /// and combines them into a single `where` clause. It handles both simple
+    /// constraints (e.g., `Item: Equatable`) and composition constraints
+    /// (e.g., `Item: Equatable & Sendable`).
+    ///
+    /// For example, given these associated types:
+    ///
+    /// ```swift
+    /// associatedtype Item: Equatable
+    /// associatedtype Value: Codable & Sendable
+    /// ```
+    ///
+    /// This method generates:
+    ///
+    /// ```swift
+    /// where Item: Equatable, Value: Codable, Value: Sendable
+    /// ```
+    ///
+    /// This is used when creating conditional conformance extensions for mocks
+    /// where different `#if` branches define conflicting constraints for the
+    /// same associated type.
+    ///
+    /// - Parameter associatedTypes: The associated type declarations from which
+    ///   to extract constraints.
+    /// - Returns: A generic `where` clause containing all the constraints, or
+    ///   `nil` if no constraints are found.
+    private static func whereClause(
+        from associatedTypes: [AssociatedTypeDeclSyntax]
+    ) -> GenericWhereClauseSyntax? {
+        let allConstraints = associatedTypes.flatMap { associatedType -> [(name: TokenSyntax, type: TypeSyntax)] in
+            guard let inheritanceClause = associatedType.inheritanceClause else {
+                return []
+            }
+
+            let identifierTypes = inheritanceClause
+                .inheritedTypes(ofType: IdentifierTypeSyntax.self)
+                .map(TypeSyntax.init)
+
+            let compositionTypes = inheritanceClause
+                .inheritedTypes(ofType: CompositionTypeSyntax.self)
+                .flatMap(\.elements)
+                .map { compositionType in
+                    TypeSyntax(compositionType.type)
+                }
+
+
+            return (identifierTypes + compositionTypes).map { type in (associatedType.name.trimmed, type) }
+        }
+
+        guard !allConstraints.isEmpty else {
+            return nil
+        }
+
+        return GenericWhereClauseSyntax {
+            allConstraints.map { constraint in
+                GenericRequirementSyntax(requirement: .conformanceRequirement(
+                    ConformanceRequirementSyntax(
+                        leftType: IdentifierTypeSyntax(name: constraint.name),
+                        colon: .colonToken(),
+                        rightType: constraint.type.trimmed
+                    )
+                ))
             }
         }
     }

--- a/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
+++ b/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
@@ -34,11 +34,11 @@ public struct MockedMacro: PeerMacro {
             mockName: mockName,
             mockGenericParameterClause: mockGenericSpecialization.mockGenericParameterClause,
             mockGenericWhereClause: mockGenericSpecialization.mockGenericWhereClause,
-            shouldMockConformToProtocol: mockGenericSpecialization.mockConditionalConformanceDeclarations.isEmpty
+            shouldMockConformToProtocol: mockGenericSpecialization.mockPeerIfConfigDeclarations.isEmpty
         )
 
         let declarations = [DeclSyntax(mockDeclaration)]
-            + mockGenericSpecialization.mockConditionalConformanceDeclarations.map(DeclSyntax.init)
+            + mockGenericSpecialization.mockPeerIfConfigDeclarations.map(DeclSyntax.init)
 
         guard let compilationCondition = macroArguments.compilationCondition.rawValue else {
             return declarations
@@ -156,60 +156,72 @@ extension MockedMacro {
     // MARK: Generic Specialization
 
     /// Returns a tuple containing a generic parameter clause, a generic where
-    /// clause, and any conditional conformance declarations needed to conform
-    /// the mock declaration to the provided `protocolDeclaration`.
+    /// clause, and zero or more `IfConfigDeclSyntax` objects containing
+    /// extensions that conditionally conform the mock to the provided
+    /// `protocolDeclaration`.
     ///
     /// - Parameters:
     ///   - mockName: The name of the mock.
     ///   - protocolDeclaration: The protocol to which the mock must conform.
     /// - Returns: A tuple containing a generic parameter clause, a generic
-    ///   where clause, and any conditional conformance declarations needed to
-    ///   conform the mock declaration to the provided `protocolDeclaration`.
+    ///   where clause, and zero or more `IfConfigDeclSyntax` objects containing
+    ///   extensions that conditionally conform the mock to the provided
+    ///   `protocolDeclaration`.
     private static func mockGenericSpecialization(
         mockName: TokenSyntax,
         protocolDeclaration: ProtocolDeclSyntax
     ) -> (
         mockGenericParameterClause: GenericParameterClauseSyntax?,
         mockGenericWhereClause: GenericWhereClauseSyntax?,
-        mockConditionalConformanceDeclarations: [IfConfigDeclSyntax]
+        mockPeerIfConfigDeclarations: [IfConfigDeclSyntax]
     ) {
         let protocolGenericRequirements = protocolDeclaration.genericWhereClause?.requirements
 
         var mockGenericParameters: [GenericParameterSyntax] = []
-        var mockGenericWhereClauseRequirements = protocolGenericRequirements?.map(\.requirement) ?? []
-        var mockConditionalConformanceDeclarations: [IfConfigDeclSyntax] = []
+        var mockGenericWhereClauseRequirements = protocolGenericRequirements?.map(
+            \.requirement
+        ) ?? []
+        var mockPeerIfConfigDeclarations: [IfConfigDeclSyntax] = []
 
         for member in protocolDeclaration.memberBlock.members {
             if let associatedTypeDeclaration = member.decl.as(AssociatedTypeDeclSyntax.self) {
-                let mockGenericParameter = self.mockGenericParameter(from: associatedTypeDeclaration)
+                let mockGenericParameter = self.mockGenericParameter(
+                    from: associatedTypeDeclaration
+                )
 
                 self.appendGenericParameter(mockGenericParameter, to: &mockGenericParameters)
 
                 if let associatedTypeGenericWhereClause = associatedTypeDeclaration.genericWhereClause {
                     mockGenericWhereClauseRequirements.append(
-                        contentsOf: associatedTypeGenericWhereClause.requirements.map(\.requirement)
+                        contentsOf: associatedTypeGenericWhereClause.requirements.map(
+                            \.requirement
+                        )
                     )
                 }
             } else if
                 let ifConfigDeclaration = member.decl.as(IfConfigDeclSyntax.self),
-                let mockConditionalConformanceDeclaration = self.mockConditionalConformanceDeclaration(
+                let mockPeerIfConfigDeclaration = self.mockPeerIfConfigDeclaration(
                     from: ifConfigDeclaration,
                     in: protocolDeclaration,
                     mockName: mockName,
                     mockGenericParameters: &mockGenericParameters
                 )
             {
-                mockConditionalConformanceDeclarations.append(mockConditionalConformanceDeclaration)
+                mockPeerIfConfigDeclarations.append(mockPeerIfConfigDeclaration)
             }
         }
 
-        let mockGenericParameterClause = self.genericParameterClause(parameters: mockGenericParameters)
-        let mockGenericWhereClause = self.genericWhereClause(requirements: mockGenericWhereClauseRequirements)
+        let mockGenericParameterClause = self.genericParameterClause(
+            parameters: mockGenericParameters
+        )
+        let mockGenericWhereClause = self.genericWhereClause(
+            requirements: mockGenericWhereClauseRequirements
+        )
 
         return (
             mockGenericParameterClause,
             mockGenericWhereClause,
-            mockConditionalConformanceDeclarations
+            mockPeerIfConfigDeclarations
         )
     }
 
@@ -222,8 +234,8 @@ extension MockedMacro {
     /// `ifConfigDeclaration`.
     ///
     /// - Parameters:
-    ///   - ifConfigDeclaration: An `IfConfigDeclSyntax` from the provided
-    ///     `protocolDeclaration`.
+    ///   - protocolIfConfigDeclaration: An `IfConfigDeclSyntax` from the
+    ///     provided `protocolDeclaration`.
     ///   - protocolDeclaration: The protocol to which the mock must conform.
     ///   - mockName: The name of the mock.
     ///   - mockGenericParameters: The mock's generic parameters.
@@ -231,27 +243,33 @@ extension MockedMacro {
     ///   conditionally conform the mock to the provided `protocolDeclaration`,
     ///   or `nil` if the mock does not need to conditionally conform to the
     ///   provided `protocolDeclaration`.
-    private static func mockConditionalConformanceDeclaration(
-        from ifConfigDeclaration: IfConfigDeclSyntax,
+    private static func mockPeerIfConfigDeclaration(
+        from protocolIfConfigDeclaration: IfConfigDeclSyntax,
         in protocolDeclaration: ProtocolDeclSyntax,
         mockName: TokenSyntax,
         mockGenericParameters: inout [GenericParameterSyntax]
     ) -> IfConfigDeclSyntax? {
-        var ifConfigClauses: [IfConfigClauseSyntax] = []
+        var mockPeerIfConfigClauses: [IfConfigClauseSyntax] = []
         var mockNeedsConditionalConformance = false
 
-        for clause in ifConfigDeclaration.clauses {
-            var mockExtensionGenericWhereClauseRequirements: [GenericRequirementSyntax.Requirement] = []
+        for protocolIfConfigClause in protocolIfConfigDeclaration.clauses {
+            var mockExtensionGenericWhereClauseRequirements: [
+                GenericRequirementSyntax.Requirement
+            ] = []
 
-            if case let .decls(members) = clause.elements {
+            if case let .decls(members) = protocolIfConfigClause.elements {
                 for member in members {
                     guard
-                        let associatedTypeDeclaration = member.decl.as(AssociatedTypeDeclSyntax.self)
+                        let associatedTypeDeclaration = member.decl.as(
+                            AssociatedTypeDeclSyntax.self
+                        )
                     else {
                         continue
                     }
 
-                    let mockGenericParameter = self.mockGenericParameter(from: associatedTypeDeclaration)
+                    let mockGenericParameter = self.mockGenericParameter(
+                        from: associatedTypeDeclaration
+                    )
 
                     self.appendGenericParameter(
                         GenericParameterSyntax(name: mockGenericParameter.name),
@@ -273,7 +291,9 @@ extension MockedMacro {
 
                     if let associatedTypeGenericWhereClause = associatedTypeDeclaration.genericWhereClause {
                         mockExtensionGenericWhereClauseRequirements.append(
-                            contentsOf: associatedTypeGenericWhereClause.requirements.map(\.requirement)
+                            contentsOf: associatedTypeGenericWhereClause.requirements.map(
+                                \.requirement
+                            )
                         )
                     }
                 }
@@ -293,9 +313,9 @@ extension MockedMacro {
                 },
                 genericWhereClause: mockExtensionGenericWhereClause
             ) {}
-            let ifConfigClause = IfConfigClauseSyntax(
-                poundKeyword: clause.poundKeyword.trimmed,
-                condition: clause.condition?.trimmed,
+            let mockPeerIfConfigClause = IfConfigClauseSyntax(
+                poundKeyword: protocolIfConfigClause.poundKeyword.trimmed,
+                condition: protocolIfConfigClause.condition?.trimmed,
                 elements: .decls(
                     MemberBlockItemListSyntax {
                         MemberBlockItemSyntax(decl: mockExtensionDeclaration)
@@ -303,14 +323,16 @@ extension MockedMacro {
                 )
             )
 
-            ifConfigClauses.append(ifConfigClause)
+            mockPeerIfConfigClauses.append(mockPeerIfConfigClause)
         }
 
         guard mockNeedsConditionalConformance else {
             return nil
         }
 
-        return IfConfigDeclSyntax(clauses: IfConfigClauseListSyntax(ifConfigClauses))
+        return IfConfigDeclSyntax(
+            clauses: IfConfigClauseListSyntax(mockPeerIfConfigClauses)
+        )
     }
 
     // MARK: Generic Parameter Clause
@@ -397,7 +419,7 @@ extension MockedMacro {
             for (index, parameter) in parameters.enumerated() {
                 parameter.with(
                     \.trailingComma,
-                     index < parameters.count - 1 ? .commaToken() : nil
+                    index < parameters.count - 1 ? .commaToken() : nil
                 )
             }
         }
@@ -447,7 +469,7 @@ extension MockedMacro {
                 for (index, inheritedType) in inheritedTypes.enumerated() {
                     inheritedType.with(
                         \.trailingComma,
-                         index < inheritedTypes.count - 1 ? .commaToken() : nil
+                        index < inheritedTypes.count - 1 ? .commaToken() : nil
                     )
                 }
             }

--- a/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
+++ b/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
@@ -24,7 +24,7 @@ public struct MockedMacro: PeerMacro {
 
         let macroArguments = MacroArguments(node: node)
         let mockName = self.mockName(from: protocolDeclaration)
-        let mockGenericSpecialization = self.mockGenericSpecialization(
+        let mockGenericConfiguration = self.mockGenericConfiguration(
             mockName: mockName,
             protocolDeclaration: protocolDeclaration
         )
@@ -32,13 +32,13 @@ public struct MockedMacro: PeerMacro {
             from: protocolDeclaration,
             macroArguments: macroArguments,
             mockName: mockName,
-            mockGenericParameterClause: mockGenericSpecialization.genericParameterClause,
-            mockGenericWhereClause: mockGenericSpecialization.genericWhereClause,
-            shouldMockConformToProtocol: mockGenericSpecialization.peerIfConfigDeclarations.isEmpty
+            mockGenericParameterClause: mockGenericConfiguration.genericParameterClause,
+            mockGenericWhereClause: mockGenericConfiguration.genericWhereClause,
+            shouldMockConformToProtocol: mockGenericConfiguration.peerIfConfigDeclarations.isEmpty
         )
 
         let declarations = [DeclSyntax(mockDeclaration)]
-            + mockGenericSpecialization.peerIfConfigDeclarations.map(DeclSyntax.init)
+            + mockGenericConfiguration.peerIfConfigDeclarations.map(DeclSyntax.init)
 
         guard let compilationCondition = macroArguments.compilationCondition.rawValue else {
             return declarations
@@ -153,7 +153,7 @@ extension MockedMacro {
         }
     }
 
-    // MARK: Generic Specialization
+    // MARK: Generic Configuration
 
     /// Returns a tuple containing a generic parameter clause, a generic where
     /// clause, and zero or more `IfConfigDeclSyntax` objects containing
@@ -167,7 +167,7 @@ extension MockedMacro {
     ///   where clause, and zero or more `IfConfigDeclSyntax` objects containing
     ///   extensions that conditionally conform the mock to the provided
     ///   `protocolDeclaration`.
-    private static func mockGenericSpecialization(
+    private static func mockGenericConfiguration(
         mockName: TokenSyntax,
         protocolDeclaration: ProtocolDeclSyntax
     ) -> (

--- a/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
+++ b/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
@@ -314,53 +314,64 @@ extension MockedMacro {
         from protocolDeclaration: ProtocolDeclSyntax
     ) throws -> MemberBlockSyntax {
         let accessLevel = protocolDeclaration.minimumConformingAccessLevel
-        let memberBlock = protocolDeclaration.memberBlock
-        let initializerDeclarations = memberBlock.memberDeclarations(
-            ofType: InitializerDeclSyntax.self
+        let transformedMembers = try self.mockMemberBlockItems(
+            from: protocolDeclaration.memberBlock.members,
+            with: accessLevel,
+            in: protocolDeclaration
         )
-        let propertyDeclarations = memberBlock.memberDeclarations(
-            ofType: VariableDeclSyntax.self
-        )
-        let methodDeclarations = memberBlock.memberDeclarations(
-            ofType: FunctionDeclSyntax.self
-        )
-        let ifConfigDeclarations = memberBlock.memberDeclarations(
-            ofType: IfConfigDeclSyntax.self
-        )
+        return MemberBlockSyntax(members: transformedMembers)
+    }
 
-        return try MemberBlockSyntax {
-            for initializerDeclaration in initializerDeclarations {
-                try self.mockInitializerConformanceDeclaration(
-                    with: accessLevel,
-                    from: initializerDeclaration
-                )
-            }
-
-            for propertyDeclaration in propertyDeclarations {
-                for binding in propertyDeclaration.bindings {
-                    try self.mockPropertyConformanceDeclaration(
-                        with: accessLevel,
-                        for: binding,
-                        from: propertyDeclaration
+    /// Transforms member block items into mocked declarations.
+    ///
+    /// Associated types are skipped since they become generic parameters on the
+    /// mock class rather than member declarations.
+    ///
+    /// - Parameters:
+    ///   - members: The member block items to transform.
+    ///   - accessLevel: The access level to apply to the mocked declarations.
+    ///   - protocolDeclaration: The protocol being mocked.
+    /// - Returns: The transformed member block items.
+    private static func mockMemberBlockItems(
+        from members: MemberBlockItemListSyntax,
+        with accessLevel: AccessLevelSyntax,
+        in protocolDeclaration: ProtocolDeclSyntax
+    ) throws -> MemberBlockItemListSyntax {
+        try MemberBlockItemListSyntax {
+            for member in members {
+                if let initializerDecl = member.decl.as(InitializerDeclSyntax.self) {
+                    MemberBlockItemSyntax(
+                        decl: try self.mockInitializerConformanceDeclaration(
+                            with: accessLevel,
+                            from: initializerDecl
+                        )
                     )
-                }
-            }
-
-            for methodDeclaration in methodDeclarations {
-                try self.mockMethodConformanceDeclaration(
-                    with: accessLevel,
-                    for: methodDeclaration,
-                    in: protocolDeclaration
-                )
-            }
-
-            for ifConfigDeclaration in ifConfigDeclarations {
-                if let mockedIfConfig = try self.mockIfConfigDeclaration(
-                    from: ifConfigDeclaration,
-                    with: accessLevel,
-                    in: protocolDeclaration
-                ) {
-                    mockedIfConfig
+                } else if let propertyDecl = member.decl.as(VariableDeclSyntax.self) {
+                    for binding in propertyDecl.bindings {
+                        MemberBlockItemSyntax(
+                            decl: try self.mockPropertyConformanceDeclaration(
+                                with: accessLevel,
+                                for: binding,
+                                from: propertyDecl
+                            )
+                        )
+                    }
+                } else if let methodDecl = member.decl.as(FunctionDeclSyntax.self) {
+                    MemberBlockItemSyntax(
+                        decl: try self.mockMethodConformanceDeclaration(
+                            with: accessLevel,
+                            for: methodDecl,
+                            in: protocolDeclaration
+                        )
+                    )
+                } else if let ifConfigDecl = member.decl.as(IfConfigDeclSyntax.self) {
+                    if let mockedIfConfig = try self.mockIfConfigDeclaration(
+                        from: ifConfigDecl,
+                        with: accessLevel,
+                        in: protocolDeclaration
+                    ) {
+                        MemberBlockItemSyntax(decl: mockedIfConfig)
+                    }
                 }
             }
         }
@@ -619,15 +630,25 @@ extension MockedMacro {
         with accessLevel: AccessLevelSyntax,
         in protocolDeclaration: ProtocolDeclSyntax
     ) throws -> IfConfigDeclSyntax? {
-        let transformedClauses = try IfConfigClauseListSyntax {
-            for clause in ifConfigDecl.clauses {
-                try self.mockIfConfigClause(
-                    from: clause,
+        let transformedClauses = try IfConfigClauseListSyntax(
+            ifConfigDecl.clauses.map { clause in
+                guard case let .decls(memberBlockItems) = clause.elements else {
+                    return clause
+                }
+
+                let transformedMembers = try self.mockMemberBlockItems(
+                    from: memberBlockItems,
                     with: accessLevel,
                     in: protocolDeclaration
                 )
+
+                return IfConfigClauseSyntax(
+                    poundKeyword: clause.poundKeyword.trimmed,
+                    condition: clause.condition?.trimmed,
+                    elements: .decls(transformedMembers)
+                )
             }
-        }
+        )
 
         let allClausesEmpty = transformedClauses.allSatisfy { clause in
             guard case let .decls(members) = clause.elements else {
@@ -643,73 +664,6 @@ extension MockedMacro {
         return IfConfigDeclSyntax(
             clauses: transformedClauses,
             poundEndif: ifConfigDecl.poundEndif.trimmed
-        )
-    }
-
-    /// Returns a transformed `IfConfigClauseSyntax` with mocked member declarations.
-    ///
-    /// Associated types are skipped since they become generic parameters on the
-    /// mock class rather than member declarations.
-    ///
-    /// - Parameters:
-    ///   - clause: The clause to transform.
-    ///   - accessLevel: The access level to apply to the mocked declarations.
-    ///   - protocolDeclaration: The protocol being mocked.
-    /// - Returns: A transformed `IfConfigClauseSyntax`.
-    private static func mockIfConfigClause(
-        from clause: IfConfigClauseSyntax,
-        with accessLevel: AccessLevelSyntax,
-        in protocolDeclaration: ProtocolDeclSyntax
-    ) throws -> IfConfigClauseSyntax {
-        guard case let .decls(memberBlockItems) = clause.elements else {
-            return clause
-        }
-
-        let transformedMembers = try MemberBlockItemListSyntax {
-            for member in memberBlockItems {
-                if let initializerDecl = member.decl.as(InitializerDeclSyntax.self) {
-                    MemberBlockItemSyntax(
-                        decl: try self.mockInitializerConformanceDeclaration(
-                            with: accessLevel,
-                            from: initializerDecl
-                        )
-                    )
-                } else if let propertyDecl = member.decl.as(VariableDeclSyntax.self) {
-                    for binding in propertyDecl.bindings {
-                        MemberBlockItemSyntax(
-                            decl: try self.mockPropertyConformanceDeclaration(
-                                with: accessLevel,
-                                for: binding,
-                                from: propertyDecl
-                            )
-                        )
-                    }
-                } else if let methodDecl = member.decl.as(FunctionDeclSyntax.self) {
-                    MemberBlockItemSyntax(
-                        decl: try self.mockMethodConformanceDeclaration(
-                            with: accessLevel,
-                            for: methodDecl,
-                            in: protocolDeclaration
-                        )
-                    )
-                } else if let nestedIfConfig = member.decl.as(IfConfigDeclSyntax.self) {
-                    if let mockedIfConfig = try self.mockIfConfigDeclaration(
-                        from: nestedIfConfig,
-                        with: accessLevel,
-                        in: protocolDeclaration
-                    ) {
-                        MemberBlockItemSyntax(decl: mockedIfConfig)
-                    }
-                }
-                // AssociatedTypeDeclSyntax is intentionally skipped since
-                // associated types become generic parameters on the mock class.
-            }
-        }
-
-        return IfConfigClauseSyntax(
-            poundKeyword: clause.poundKeyword.trimmed,
-            condition: clause.condition?.trimmed,
-            elements: .decls(transformedMembers)
         )
     }
 }

--- a/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
+++ b/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
@@ -328,14 +328,6 @@ extension MockedMacro {
             ofType: IfConfigDeclSyntax.self
         )
 
-        let mockedIfConfigDeclarations: [IfConfigDeclSyntax] = try ifConfigDeclarations.compactMap {
-            try self.mockIfConfigDeclaration(
-                from: $0,
-                with: accessLevel,
-                in: protocolDeclaration
-            )
-        }
-
         return try MemberBlockSyntax {
             for initializerDeclaration in initializerDeclarations {
                 try self.mockInitializerConformanceDeclaration(
@@ -362,8 +354,14 @@ extension MockedMacro {
                 )
             }
 
-            for mockedIfConfig in mockedIfConfigDeclarations {
-                mockedIfConfig
+            for ifConfigDeclaration in ifConfigDeclarations {
+                if let mockedIfConfig = try self.mockIfConfigDeclaration(
+                    from: ifConfigDeclaration,
+                    with: accessLevel,
+                    in: protocolDeclaration
+                ) {
+                    mockedIfConfig
+                }
             }
         }
     }
@@ -703,7 +701,7 @@ extension MockedMacro {
                         MemberBlockItemSyntax(decl: mockedIfConfig)
                     }
                 }
-                // AssociatedTypeDeclSyntax is intentionally skipped here since
+                // AssociatedTypeDeclSyntax is intentionally skipped since
                 // associated types become generic parameters on the mock class.
             }
         }

--- a/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
+++ b/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
@@ -742,11 +742,11 @@ extension MockedMacro {
                     })
                 }
 
-                let hasConflictingConstraints = constraintSetsByTypeName.values
-                    .contains { constraints in
-                        constraints.count > 1
-                    }
-                return hasConflictingConstraints ? clauses : nil
+                guard constraintSetsByTypeName.values.contains(where: { $0.count > 1 }) else {
+                    return nil
+                }
+
+                return clauses
             }
             .first
     }

--- a/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
+++ b/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
@@ -23,47 +23,25 @@ public struct MockedMacro: PeerMacro {
         }
 
         let macroArguments = MacroArguments(node: node)
-
-        if let conflictingConditionalClauses = self.conflictingConditionalClauses(
-            from: protocolDeclaration.memberBlock.members
-        ) {
-            return try self.expansionWithConditionalConformance(
-                protocolDeclaration: protocolDeclaration,
-                macroArguments: macroArguments,
-                clauses: conflictingConditionalClauses
-            )
-        }
-
-        let mockDeclaration = DeclSyntax(
-            ClassDeclSyntax(
-                attributes: AttributeListSyntax {
-                    AttributeSyntax(
-                        atSign: .atSignToken(),
-                        attributeName: IdentifierTypeSyntax(name: "MockedMembers"),
-                        trailingTrivia: .newline
-                    )
-                },
-                modifiers: self.mockModifiers(from: protocolDeclaration),
-                classKeyword: .keyword(
-                    protocolDeclaration.isActorConstrained ? .actor : .class
-                ),
-                name: self.mockName(from: protocolDeclaration),
-                genericParameterClause: self.mockGenericParameterClause(
-                    from: protocolDeclaration
-                ),
-                inheritanceClause: self.mockInheritanceClause(
-                    from: protocolDeclaration,
-                    sendableConformance: macroArguments.sendableConformance
-                ),
-                genericWhereClause: self.mockGenericWhereClause(
-                    from: protocolDeclaration
-                ),
-                memberBlock: try self.mockMemberBlock(from: protocolDeclaration)
-            )
+        let mockName = self.mockName(from: protocolDeclaration)
+        let mockGenericSpecialization = self.mockGenericSpecialization(
+            mockName: mockName,
+            protocolDeclaration: protocolDeclaration
+        )
+        let mockDeclaration = try self.mockDeclaration(
+            from: protocolDeclaration,
+            macroArguments: macroArguments,
+            mockName: mockName,
+            mockGenericParameterClause: mockGenericSpecialization.mockGenericParameterClause,
+            mockGenericWhereClause: mockGenericSpecialization.mockGenericWhereClause,
+            shouldMockConformToProtocol: mockGenericSpecialization.mockConditionalConformanceDeclarations.isEmpty
         )
 
+        let declarations = [DeclSyntax(mockDeclaration)]
+            + mockGenericSpecialization.mockConditionalConformanceDeclarations.map(DeclSyntax.init)
+
         guard let compilationCondition = macroArguments.compilationCondition.rawValue else {
-            return [mockDeclaration]
+            return declarations
         }
 
         let ifConfigDeclaration = IfConfigDeclSyntax(
@@ -75,7 +53,9 @@ public struct MockedMacro: PeerMacro {
                     ),
                     elements: .statements(
                         CodeBlockItemListSyntax {
-                            CodeBlockItemSyntax(item: .decl(mockDeclaration))
+                            for declaration in declarations {
+                                CodeBlockItemSyntax(item: .decl(declaration))
+                            }
                         }
                     )
                 )
@@ -90,9 +70,56 @@ public struct MockedMacro: PeerMacro {
 
 extension MockedMacro {
 
+    // MARK: Declaration
+
+    /// Returns a mock declaration, generated from the provided protocol.
+    ///
+    /// - Parameters:
+    ///   - protocolDeclaration: The protocol to which the mock must conform.
+    ///   - macroArguments: The arguments passed to the macro.
+    ///   - mockName: The name of the mock.
+    ///   - mockGenericParameterClause: The mock's generic parameter clause.
+    ///   - mockGenericWhereClause: The mock's generic where clause.
+    ///   - shouldMockConformToProtocol: A Boolean value indicating whether the
+    ///     mock should conform to the protocol. If the mock has extensions that
+    ///     handle conditional conformance, this value should be `false`.
+    /// - Returns: A mock declaration.
+    private static func mockDeclaration(
+        from protocolDeclaration: ProtocolDeclSyntax,
+        macroArguments: MacroArguments,
+        mockName: TokenSyntax,
+        mockGenericParameterClause: GenericParameterClauseSyntax?,
+        mockGenericWhereClause: GenericWhereClauseSyntax?,
+        shouldMockConformToProtocol: Bool
+    ) throws -> ClassDeclSyntax {
+        ClassDeclSyntax(
+            attributes: AttributeListSyntax {
+                AttributeSyntax(
+                    atSign: .atSignToken(),
+                    attributeName: IdentifierTypeSyntax(name: "MockedMembers"),
+                    trailingTrivia: .newline
+                )
+            },
+            modifiers: self.mockModifiers(from: protocolDeclaration),
+            classKeyword: .keyword(protocolDeclaration.isActorConstrained ? .actor : .class),
+            name: mockName,
+            genericParameterClause: mockGenericParameterClause,
+            inheritanceClause: self.mockInheritanceClause(
+                from: protocolDeclaration,
+                shouldConformToProtocol: shouldMockConformToProtocol,
+                sendableConformance: macroArguments.sendableConformance
+            ),
+            genericWhereClause: mockGenericWhereClause,
+            memberBlock: try self.mockMemberBlock(from: protocolDeclaration)
+        )
+    }
+
     // MARK: Name
 
-    /// Returns the type name of the mock.
+    /// Returns the name of the mock, generated from the provided protocol.
+    ///
+    /// - Parameter protocolDeclaration: The protocol being mocked.
+    /// - Returns: The name of the mock.
     private static func mockName(
         from protocolDeclaration: ProtocolDeclSyntax
     ) -> TokenSyntax {
@@ -126,128 +153,253 @@ extension MockedMacro {
         }
     }
 
-    // MARK: Generic Parameter Clause
+    // MARK: Generic Specialization
 
-    /// Returns the generic parameter clause to apply to the mock declaration,
-    /// generated from the associated types defined by the provided protocol.
-    ///
-    /// The clause supports associated types with comma-separated constraints,
-    /// composition (`&`), or a combination of both. Associated types inside
-    /// `#if` blocks are also extracted.
-    ///
-    /// ```swift
-    /// @Mocked
-    /// protocol Dependency {
-    ///     associatedtype Item: Equatable & Identifiable, Sendable
-    /// }
-    ///
-    /// final class DependencyMock<Item: Sendable & Equatable & Identifiable>: Dependency {}
-    /// ```
+    /// Returns a tuple containing a generic parameter clause, a generic where
+    /// clause, and any conditional conformance declarations needed to conform
+    /// the mock declaration to the provided `protocolDeclaration`.
     ///
     /// - Parameters:
+    ///   - mockName: The name of the mock.
     ///   - protocolDeclaration: The protocol to which the mock must conform.
-    ///   - excludingConstraintsFor: Names of associated types whose constraints
-    ///     should be excluded (used for conditional conformance).
-    /// - Returns: The generic parameter clause to apply to the mock declaration.
-    private static func mockGenericParameterClause(
-        from protocolDeclaration: ProtocolDeclSyntax,
-        excludingConstraintsFor excludedNames: Set<String> = []
-    ) -> GenericParameterClauseSyntax? {
-        let memberBlock = protocolDeclaration.memberBlock
-        let associatedTypeDeclarations = self.associatedTypeDeclarations(
-            from: memberBlock.members
-        )
+    /// - Returns: A tuple containing a generic parameter clause, a generic
+    ///   where clause, and any conditional conformance declarations needed to
+    ///   conform the mock declaration to the provided `protocolDeclaration`.
+    private static func mockGenericSpecialization(
+        mockName: TokenSyntax,
+        protocolDeclaration: ProtocolDeclSyntax
+    ) -> (
+        mockGenericParameterClause: GenericParameterClauseSyntax?,
+        mockGenericWhereClause: GenericWhereClauseSyntax?,
+        mockConditionalConformanceDeclarations: [IfConfigDeclSyntax]
+    ) {
+        let protocolGenericRequirements = protocolDeclaration.genericWhereClause?.requirements
 
-        guard !associatedTypeDeclarations.isEmpty else {
+        var mockGenericParameters: [GenericParameterSyntax] = []
+        var mockGenericWhereClauseRequirements = protocolGenericRequirements?.map(\.requirement) ?? []
+        var mockConditionalConformanceDeclarations: [IfConfigDeclSyntax] = []
+
+        for member in protocolDeclaration.memberBlock.members {
+            if let associatedTypeDeclaration = member.decl.as(AssociatedTypeDeclSyntax.self) {
+                let mockGenericParameter = self.mockGenericParameter(from: associatedTypeDeclaration)
+
+                self.appendGenericParameter(mockGenericParameter, to: &mockGenericParameters)
+
+                if let associatedTypeGenericWhereClause = associatedTypeDeclaration.genericWhereClause {
+                    mockGenericWhereClauseRequirements.append(
+                        contentsOf: associatedTypeGenericWhereClause.requirements.map(\.requirement)
+                    )
+                }
+            } else if
+                let ifConfigDeclaration = member.decl.as(IfConfigDeclSyntax.self),
+                let mockConditionalConformanceDeclaration = self.mockConditionalConformanceDeclaration(
+                    from: ifConfigDeclaration,
+                    in: protocolDeclaration,
+                    mockName: mockName,
+                    mockGenericParameters: &mockGenericParameters
+                )
+            {
+                mockConditionalConformanceDeclarations.append(mockConditionalConformanceDeclaration)
+            }
+        }
+
+        let mockGenericParameterClause = self.genericParameterClause(parameters: mockGenericParameters)
+        let mockGenericWhereClause = self.genericWhereClause(requirements: mockGenericWhereClauseRequirements)
+
+        return (
+            mockGenericParameterClause,
+            mockGenericWhereClause,
+            mockConditionalConformanceDeclarations
+        )
+    }
+
+    /// Returns an `IfConfigDeclSyntax` containing extensions that conditionally
+    /// conform the mock to the provided `protocolDeclaration`, or `nil` if the
+    /// mock does not need to conditionally conform to the provided
+    /// `protocolDeclaration`.
+    ///
+    /// This method maintains the structure and conditions of the provided
+    /// `ifConfigDeclaration`.
+    ///
+    /// - Parameters:
+    ///   - ifConfigDeclaration: An `IfConfigDeclSyntax` from the provided
+    ///     `protocolDeclaration`.
+    ///   - protocolDeclaration: The protocol to which the mock must conform.
+    ///   - mockName: The name of the mock.
+    ///   - mockGenericParameters: The mock's generic parameters.
+    /// - Returns: An `IfConfigDeclSyntax` containing extensions that
+    ///   conditionally conform the mock to the provided `protocolDeclaration`,
+    ///   or `nil` if the mock does not need to conditionally conform to the
+    ///   provided `protocolDeclaration`.
+    private static func mockConditionalConformanceDeclaration(
+        from ifConfigDeclaration: IfConfigDeclSyntax,
+        in protocolDeclaration: ProtocolDeclSyntax,
+        mockName: TokenSyntax,
+        mockGenericParameters: inout [GenericParameterSyntax]
+    ) -> IfConfigDeclSyntax? {
+        var ifConfigClauses: [IfConfigClauseSyntax] = []
+        var mockNeedsConditionalConformance = false
+
+        for clause in ifConfigDeclaration.clauses {
+            var mockExtensionGenericWhereClauseRequirements: [GenericRequirementSyntax.Requirement] = []
+
+            if case let .decls(members) = clause.elements {
+                for member in members {
+                    guard
+                        let associatedTypeDeclaration = member.decl.as(AssociatedTypeDeclSyntax.self)
+                    else {
+                        continue
+                    }
+
+                    let mockGenericParameter = self.mockGenericParameter(from: associatedTypeDeclaration)
+
+                    self.appendGenericParameter(
+                        GenericParameterSyntax(name: mockGenericParameter.name),
+                        to: &mockGenericParameters
+                    )
+
+                    if let mockGenericParameterInheritedType = mockGenericParameter.inheritedType {
+                        mockExtensionGenericWhereClauseRequirements.append(
+                            .conformanceRequirement(
+                                ConformanceRequirementSyntax(
+                                    leftType: IdentifierTypeSyntax(
+                                        name: mockGenericParameter.name
+                                    ),
+                                    rightType: mockGenericParameterInheritedType
+                                )
+                            )
+                        )
+                    }
+
+                    if let associatedTypeGenericWhereClause = associatedTypeDeclaration.genericWhereClause {
+                        mockExtensionGenericWhereClauseRequirements.append(
+                            contentsOf: associatedTypeGenericWhereClause.requirements.map(\.requirement)
+                        )
+                    }
+                }
+            }
+
+            if !mockExtensionGenericWhereClauseRequirements.isEmpty {
+                mockNeedsConditionalConformance = true
+            }
+
+            let mockExtensionGenericWhereClause = self.genericWhereClause(
+                requirements: mockExtensionGenericWhereClauseRequirements
+            )
+            let mockExtensionDeclaration = ExtensionDeclSyntax(
+                extendedType: IdentifierTypeSyntax(name: mockName),
+                inheritanceClause: InheritanceClauseSyntax {
+                    InheritedTypeSyntax(type: protocolDeclaration.type)
+                },
+                genericWhereClause: mockExtensionGenericWhereClause
+            ) {}
+            let ifConfigClause = IfConfigClauseSyntax(
+                poundKeyword: clause.poundKeyword.trimmed,
+                condition: clause.condition?.trimmed,
+                elements: .decls(
+                    MemberBlockItemListSyntax {
+                        MemberBlockItemSyntax(decl: mockExtensionDeclaration)
+                    }
+                )
+            )
+
+            ifConfigClauses.append(ifConfigClause)
+        }
+
+        guard mockNeedsConditionalConformance else {
             return nil
         }
 
-        // Deduplicate by name (same associated type may appear in multiple #if branches)
-        var seenNames: Set<String> = []
-        let uniqueAssociatedTypes = associatedTypeDeclarations.filter { decl in
-            let name = decl.name.text
-            if seenNames.contains(name) {
-                return false
+        return IfConfigDeclSyntax(clauses: IfConfigClauseListSyntax(ifConfigClauses))
+    }
+
+    // MARK: Generic Parameter Clause
+
+    /// Returns a generic parameter to apply to the mock, generated from the
+    /// provided `associatedTypeDeclaration`.
+    ///
+    /// - Parameter associatedTypeDeclaration: An associated type declaration
+    ///   from the protocol to which the mock must conform.
+    /// - Returns: A generic parameter to apply to the mock.
+    private static func mockGenericParameter(
+        from associatedTypeDeclaration: AssociatedTypeDeclSyntax
+    ) -> GenericParameterSyntax {
+        let genericParameterName = associatedTypeDeclaration.name.trimmed
+
+        guard let inheritanceClause = associatedTypeDeclaration.inheritanceClause else {
+            return GenericParameterSyntax(name: genericParameterName)
+        }
+
+        let commaSeparatedInheritedTypes = inheritanceClause
+            .inheritedTypes(ofType: IdentifierTypeSyntax.self)
+            .compactMap { CompositionTypeElementSyntax(type: $0) }
+
+        let composedInheritedTypes = inheritanceClause
+            .inheritedTypes(ofType: CompositionTypeSyntax.self)
+            .flatMap(\.elements)
+
+        let inheritedTypes = commaSeparatedInheritedTypes + composedInheritedTypes
+        let lastIndex = inheritedTypes.count - 1
+        let inheritedTypeElements = CompositionTypeElementListSyntax {
+            for (index, inheritedType) in inheritedTypes.enumerated() {
+                inheritedType
+                    .trimmed
+                    .with(\.ampersand, index < lastIndex ? .binaryOperator("&") : nil)
             }
-            seenNames.insert(name)
-            return true
+        }
+
+        return GenericParameterSyntax(
+            name: genericParameterName,
+            colon: .colonToken(),
+            inheritedType: CompositionTypeSyntax(elements: inheritedTypeElements)
+        )
+    }
+
+    /// Appends the provided `genericParameter` to the provided
+    /// `genericParameters`, unless another generic parameter of the same name
+    /// already exists, in which case this method does nothing.
+    ///
+    /// - Parameters:
+    ///   - genericParameter: The generic parameter to append to the provided
+    ///     `genericParameters`.
+    ///   - genericParameters: The generic parameters to which to append the
+    ///     provided `genericParameter`.
+    private static func appendGenericParameter(
+        _ genericParameter: GenericParameterSyntax,
+        to genericParameters: inout [GenericParameterSyntax]
+    ) {
+        let isDuplicate = genericParameters.contains { existingGenericParameter in
+            genericParameter.name.tokenKind == existingGenericParameter.name.tokenKind
+        }
+
+        guard !isDuplicate else {
+            return
+        }
+
+        genericParameters.append(genericParameter)
+    }
+
+    /// Returns a generic parameter clause with the provided `parameters`, or
+    /// `nil` if `parameters` is empty.
+    ///
+    /// - Parameter parameters: The generic parameters to include in the generic
+    ///   parameter clause.
+    /// - Returns: A generic parameter clause with the provided `parameters`, or
+    ///   `nil` if `parameters` is empty.
+    private static func genericParameterClause(
+        parameters: [GenericParameterSyntax]
+    ) -> GenericParameterClauseSyntax? {
+        guard !parameters.isEmpty else {
+            return nil
         }
 
         return GenericParameterClauseSyntax {
-            for associatedTypeDeclaration in uniqueAssociatedTypes {
-                let genericParameterName = associatedTypeDeclaration.name.trimmed
-                let shouldExcludeConstraints = excludedNames
-                    .contains(associatedTypeDeclaration.name.text)
-
-                if !shouldExcludeConstraints,
-                   let inheritanceClause = associatedTypeDeclaration.inheritanceClause
-                {
-                    let commaSeparatedInheritedTypes = inheritanceClause
-                        .inheritedTypes(ofType: IdentifierTypeSyntax.self)
-                        .compactMap { CompositionTypeElementSyntax(type: $0) }
-
-                    let composedInheritedTypes = inheritanceClause
-                        .inheritedTypes(ofType: CompositionTypeSyntax.self)
-                        .flatMap(\.elements)
-
-                    let inheritedTypes = commaSeparatedInheritedTypes + composedInheritedTypes
-                    let lastIndex = inheritedTypes.count - 1
-                    let inheritedTypeElements = CompositionTypeElementListSyntax {
-                        for (index, inheritedType) in inheritedTypes.enumerated() {
-                            inheritedType
-                                .trimmed
-                                .with(\.ampersand, index < lastIndex ? .binaryOperator("&") : nil)
-                        }
-                    }
-
-                    GenericParameterSyntax(
-                        name: genericParameterName,
-                        colon: .colonToken(),
-                        inheritedType: CompositionTypeSyntax(elements: inheritedTypeElements)
-                    )
-                } else {
-                    GenericParameterSyntax(name: genericParameterName)
-                }
+            for (index, parameter) in parameters.enumerated() {
+                parameter.with(
+                    \.trailingComma,
+                     index < parameters.count - 1 ? .commaToken() : nil
+                )
             }
-        }
-    }
-
-    /// Returns the associated type declarations from the provided `members`,
-    /// including those inside `#if` declarations.
-    ///
-    /// - Parameter members: The members to search.
-    /// - Returns: The associated type declarations from the provided `members`.
-    private static func associatedTypeDeclarations(
-        from members: MemberBlockItemListSyntax
-    ) -> [AssociatedTypeDeclSyntax] {
-        members.flatMap { member -> [AssociatedTypeDeclSyntax] in
-            if let associatedTypeDeclaration = member.decl.as(AssociatedTypeDeclSyntax.self) {
-                return [associatedTypeDeclaration]
-            } else if let ifConfigDeclaration = member.decl.as(IfConfigDeclSyntax.self) {
-                return self.associatedTypeDeclarations(from: ifConfigDeclaration)
-            } else {
-                return []
-            }
-        }
-    }
-
-    /// Returns the associated type declarations from the provided
-    /// `ifConfigDeclaration`.
-    ///
-    /// This method recursively searches nested `#if` declarations.
-    ///
-    /// - Parameter ifConfigDeclaration: The `#if` declaration to search.
-    /// - Returns: The associated type declarations from the provided
-    ///   `ifConfigDeclaration`.
-    private static func associatedTypeDeclarations(
-        from ifConfigDeclaration: IfConfigDeclSyntax
-    ) -> [AssociatedTypeDeclSyntax] {
-        ifConfigDeclaration.clauses.flatMap { clause -> [AssociatedTypeDeclSyntax] in
-            guard case let .decls(members) = clause.elements else {
-                return []
-            }
-
-            return self.associatedTypeDeclarations(from: members)
         }
     }
 
@@ -264,46 +416,66 @@ extension MockedMacro {
     /// ```
     ///
     /// - Parameters:
-    ///   - protocolDeclaration: The protocol to which the mock must
-    ///     conform.
+    ///   - protocolDeclaration: The protocol to which the mock must conform.
+    ///   - shouldConformToProtocol: A Boolean value indicating whether the mock
+    ///     should conform to the protocol. If the mock has extensions that
+    ///     handle conditional conformance, this value should be `false`.
     ///   - sendableConformance: The `Sendable` conformance the mock should have.
     ///     If `.unchecked`, the inheritance clause will include `@unchecked Sendable`.
     /// - Returns: The inheritance clause to apply to the mock declaration.
     private static func mockInheritanceClause(
         from protocolDeclaration: ProtocolDeclSyntax,
+        shouldConformToProtocol: Bool,
         sendableConformance: MockSendableConformance
-    ) -> InheritanceClauseSyntax {
-        InheritanceClauseSyntax {
+    ) -> InheritanceClauseSyntax? {
+        var inheritedTypes: [InheritedTypeSyntax] = []
+
+        if case .unchecked = sendableConformance {
+            inheritedTypes.append(.uncheckedSendable)
+        }
+
+        if shouldConformToProtocol {
+            inheritedTypes.append(InheritedTypeSyntax(type: protocolDeclaration.type))
+        }
+
+        guard !inheritedTypes.isEmpty else {
+            return nil
+        }
+
+        return InheritanceClauseSyntax {
             InheritedTypeListSyntax {
-                if case .unchecked = sendableConformance {
-                    .uncheckedSendable
-                        .with(\.trailingComma, .commaToken())
+                for (index, inheritedType) in inheritedTypes.enumerated() {
+                    inheritedType.with(
+                        \.trailingComma,
+                         index < inheritedTypes.count - 1 ? .commaToken() : nil
+                    )
                 }
-                InheritedTypeSyntax(type: protocolDeclaration.type)
             }
         }
     }
 
     // MARK: Generic Where Clause
 
-    /// Returns the generic `where` clause to apply to the mock declaration,
-    /// generated from the generic `where` clause of the provided protocol and
-    /// the generic `where` clauses of the provided protocol's associated types.
+    /// Returns a generic `where` clause generated from the provided generic
+    /// requirements.
     ///
-    /// - Parameter protocolDeclaration: The protocol to which the mock must
-    ///   conform.
-    /// - Returns: The generic `where` clause to apply to the mock declaration.
-    private static func mockGenericWhereClause(
-        from protocolDeclaration: ProtocolDeclSyntax
+    /// - Parameter requirements: The requirements to apply to the generic
+    ///   `where` clause.
+    /// - Returns: A generic `where` clause.
+    private static func genericWhereClause(
+        requirements: [GenericRequirementSyntax.Requirement]
     ) -> GenericWhereClauseSyntax? {
-        guard !protocolDeclaration.genericWhereClauses.isEmpty else {
+        guard !requirements.isEmpty else {
             return nil
         }
 
         return GenericWhereClauseSyntax {
-            protocolDeclaration.genericWhereClauses
-                .flatMap(\.requirements)
-                .map(\.trimmed)
+            for (index, requirement) in requirements.enumerated() {
+                GenericRequirementSyntax(
+                    requirement: requirement.trimmed,
+                    trailingComma: index < requirements.count - 1 ? .commaToken() : nil
+                )
+            }
         }
     }
 
@@ -675,242 +847,6 @@ extension MockedMacro {
 
             for modifier in modifiers where !modifier.isAccessLevel {
                 modifier.trimmed
-            }
-        }
-    }
-}
-
-// MARK: - Conditional Associated Type Conformance
-
-extension MockedMacro {
-
-    /// A tuple representing one clause of an `#if` block containing associated
-    /// types with their conditional compilation condition.
-    ///
-    /// - `condition`: The conditional compilation expression (e.g., `DEBUG`),
-    ///   or `nil` for `#else` clauses.
-    /// - `associatedTypes`: The associated type declarations within this clause.
-    private typealias ConditionalClause = (
-        condition: ExprSyntax?,
-        associatedTypes: [AssociatedTypeDeclSyntax]
-    )
-
-    /// Returns conditional clauses containing associated types with conflicting
-    /// constraints across different `#if` branches.
-    ///
-    /// This method detects when the same associated type has different constraints
-    /// in different conditional compilation branches, requiring conditional conformance.
-    ///
-    /// - Parameter members: The protocol members to search for conflicting
-    ///   conditional associated types.
-    /// - Returns: An array of conditional clauses if conflicts are found, or
-    ///   `nil` if there are no conflicts.
-    private static func conflictingConditionalClauses(
-        from members: MemberBlockItemListSyntax
-    ) -> [ConditionalClause]? {
-        members
-            .compactMap { member in member.decl.as(IfConfigDeclSyntax.self) }
-            .compactMap { ifConfigDeclaration -> [ConditionalClause]? in
-                let clauses = ifConfigDeclaration.clauses
-                    .compactMap { clause -> ConditionalClause? in
-                        guard case let .decls(declarations) = clause.elements else {
-                            return nil
-                        }
-
-                        let associatedTypes = declarations.compactMap { declaration in
-                            declaration.decl.as(AssociatedTypeDeclSyntax.self)
-                        }
-
-                        guard !associatedTypes.isEmpty else {
-                            return nil
-                        }
-
-                        return (clause.condition, associatedTypes)
-                    }
-
-                guard !clauses.isEmpty else {
-                    return nil
-                }
-
-                let constraintSetsByTypeName = Dictionary(
-                    grouping: clauses.flatMap(\.associatedTypes),
-                    by: \.name.text
-                ).mapValues { types in
-                    Set(types.map { type in
-                        type.inheritanceClause?.description
-                            .trimmingCharacters(in: .whitespaces) ?? ""
-                    })
-                }
-
-                guard constraintSetsByTypeName.values.contains(where: { $0.count > 1 }) else {
-                    return nil
-                }
-
-                return clauses
-            }
-            .first
-    }
-
-    /// Returns the macro expansion with conditional conformance extensions
-    /// for protocols with conflicting associated type constraints in `#if` blocks.
-    ///
-    /// This method generates a mock class without associated type constraints,
-    /// along with conditional extensions that conform to the protocol under
-    /// specific compilation conditions with the appropriate constraints applied.
-    ///
-    /// - Parameters:
-    ///   - protocolDeclaration: The protocol to which the mock must conform.
-    ///   - macroArguments: The macro arguments provided to the `@Mocked` attribute.
-    ///   - clauses: The conditional clauses containing conflicting associated
-    ///     type constraints.
-    /// - Returns: The declarations to generate, including the mock class and
-    ///   conditional conformance extensions.
-    private static func expansionWithConditionalConformance(
-        protocolDeclaration: ProtocolDeclSyntax,
-        macroArguments: MacroArguments,
-        clauses: [ConditionalClause]
-    ) throws -> [DeclSyntax] {
-        let mockName = self.mockName(from: protocolDeclaration)
-        let associatedTypeNamesToExclude = Set(clauses.flatMap { clause in
-            clause.associatedTypes.map(\.name.text)
-        })
-
-        let mockDeclaration = ClassDeclSyntax(
-            attributes: AttributeListSyntax {
-                AttributeSyntax(
-                    atSign: .atSignToken(),
-                    attributeName: IdentifierTypeSyntax(name: "MockedMembers"),
-                    trailingTrivia: .newline
-                )
-            },
-            modifiers: self.mockModifiers(from: protocolDeclaration),
-            classKeyword: .keyword(protocolDeclaration.isActorConstrained ? .actor : .class),
-            name: mockName,
-            genericParameterClause: self.mockGenericParameterClause(
-                from: protocolDeclaration,
-                excludingConstraintsFor: associatedTypeNamesToExclude
-            ),
-            inheritanceClause: macroArguments.sendableConformance == .unchecked
-                ? InheritanceClauseSyntax { InheritedTypeSyntax.uncheckedSendable }
-                : nil,
-            genericWhereClause: self.mockGenericWhereClause(from: protocolDeclaration),
-            memberBlock: try self.mockMemberBlock(from: protocolDeclaration)
-        )
-
-        let ifConfigDeclaration = IfConfigDeclSyntax(
-            clauses: IfConfigClauseListSyntax(
-                clauses.enumerated().map { index, clause in
-                    IfConfigClauseSyntax(
-                        poundKeyword: index == 0
-                            ? .poundIfToken()
-                            : clause.condition != nil ? .poundElseifToken() : .poundElseToken(),
-                        condition: clause.condition,
-                        elements: .decls(MemberBlockItemListSyntax {
-                            MemberBlockItemSyntax(decl: ExtensionDeclSyntax(
-                                extendedType: IdentifierTypeSyntax(name: mockName),
-                                inheritanceClause: InheritanceClauseSyntax {
-                                    InheritedTypeSyntax(type: protocolDeclaration.type)
-                                },
-                                genericWhereClause: self.whereClause(from: clause.associatedTypes),
-                                memberBlock: MemberBlockSyntax(members: [])
-                            ))
-                        })
-                    )
-                }
-            )
-        )
-
-        let declarations: [DeclSyntax] = [
-            DeclSyntax(mockDeclaration),
-            DeclSyntax(ifConfigDeclaration),
-        ]
-
-        guard let condition = macroArguments.compilationCondition.rawValue else {
-            return declarations
-        }
-
-        return [DeclSyntax(IfConfigDeclSyntax(clauses: IfConfigClauseListSyntax {
-            IfConfigClauseSyntax(
-                poundKeyword: .poundIfToken(),
-                condition: DeclReferenceExprSyntax(baseName: .identifier(condition)),
-                elements: .statements(CodeBlockItemListSyntax(
-                    declarations.map { declaration in
-                        CodeBlockItemSyntax(item: .decl(declaration))
-                    }
-                ))
-            )
-        }))]
-    }
-
-    /// Builds a generic `where` clause from associated type constraints.
-    ///
-    /// This method extracts all constraints from the provided associated types
-    /// and combines them into a single `where` clause. It handles both simple
-    /// constraints (e.g., `Item: Equatable`) and composition constraints
-    /// (e.g., `Item: Equatable & Sendable`).
-    ///
-    /// For example, given these associated types:
-    ///
-    /// ```swift
-    /// associatedtype Item: Equatable
-    /// associatedtype Value: Codable & Sendable
-    /// ```
-    ///
-    /// This method generates:
-    ///
-    /// ```swift
-    /// where Item: Equatable, Value: Codable, Value: Sendable
-    /// ```
-    ///
-    /// This is used when creating conditional conformance extensions for mocks
-    /// where different `#if` branches define conflicting constraints for the
-    /// same associated type.
-    ///
-    /// - Parameter associatedTypes: The associated type declarations from which
-    ///   to extract constraints.
-    /// - Returns: A generic `where` clause containing all the constraints, or
-    ///   `nil` if no constraints are found.
-    private static func whereClause(
-        from associatedTypes: [AssociatedTypeDeclSyntax]
-    ) -> GenericWhereClauseSyntax? {
-        let allConstraints = associatedTypes.flatMap { associatedType -> [(
-            name: TokenSyntax,
-            type: TypeSyntax
-        )] in
-            guard let inheritanceClause = associatedType.inheritanceClause else {
-                return []
-            }
-
-            let identifierTypes = inheritanceClause
-                .inheritedTypes(ofType: IdentifierTypeSyntax.self)
-                .map(TypeSyntax.init)
-
-            let compositionTypes = inheritanceClause
-                .inheritedTypes(ofType: CompositionTypeSyntax.self)
-                .flatMap(\.elements)
-                .map { compositionType in
-                    TypeSyntax(compositionType.type)
-                }
-
-            return (identifierTypes + compositionTypes).map { type in (
-                associatedType.name.trimmed,
-                type
-            ) }
-        }
-
-        guard !allConstraints.isEmpty else {
-            return nil
-        }
-
-        return GenericWhereClauseSyntax {
-            allConstraints.map { constraint in
-                GenericRequirementSyntax(requirement: .conformanceRequirement(
-                    ConformanceRequirementSyntax(
-                        leftType: IdentifierTypeSyntax(name: constraint.name),
-                        colon: .colonToken(),
-                        rightType: constraint.type.trimmed
-                    )
-                ))
             }
         }
     }

--- a/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
+++ b/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
@@ -176,10 +176,12 @@ extension MockedMacro {
         return GenericParameterClauseSyntax {
             for associatedTypeDeclaration in uniqueAssociatedTypes {
                 let genericParameterName = associatedTypeDeclaration.name.trimmed
-                let shouldExcludeConstraints = excludedNames.contains(associatedTypeDeclaration.name.text)
+                let shouldExcludeConstraints = excludedNames
+                    .contains(associatedTypeDeclaration.name.text)
 
                 if !shouldExcludeConstraints,
-                   let inheritanceClause = associatedTypeDeclaration.inheritanceClause {
+                   let inheritanceClause = associatedTypeDeclaration.inheritanceClause
+                {
                     let commaSeparatedInheritedTypes = inheritanceClause
                         .inheritedTypes(ofType: IdentifierTypeSyntax.self)
                         .compactMap { CompositionTypeElementSyntax(type: $0) }
@@ -709,32 +711,41 @@ extension MockedMacro {
         members
             .compactMap { member in member.decl.as(IfConfigDeclSyntax.self) }
             .compactMap { ifConfigDeclaration -> [ConditionalClause]? in
-                let clauses = ifConfigDeclaration.clauses.compactMap { clause -> ConditionalClause? in
-                    guard case let .decls(declarations) = clause.elements else { return nil }
+                let clauses = ifConfigDeclaration.clauses
+                    .compactMap { clause -> ConditionalClause? in
+                        guard case let .decls(declarations) = clause.elements else {
+                            return nil
+                        }
 
-                    let associatedTypes = declarations.compactMap { declaration in
-                        declaration.decl.as(AssociatedTypeDeclSyntax.self)
+                        let associatedTypes = declarations.compactMap { declaration in
+                            declaration.decl.as(AssociatedTypeDeclSyntax.self)
+                        }
+
+                        guard !associatedTypes.isEmpty else {
+                            return nil
+                        }
+
+                        return (clause.condition, associatedTypes)
                     }
 
-                    guard !associatedTypes.isEmpty else { return nil }
-
-                    return (clause.condition, associatedTypes)
+                guard !clauses.isEmpty else {
+                    return nil
                 }
-
-                guard !clauses.isEmpty else { return nil }
 
                 let constraintSetsByTypeName = Dictionary(
                     grouping: clauses.flatMap(\.associatedTypes),
                     by: \.name.text
                 ).mapValues { types in
                     Set(types.map { type in
-                        type.inheritanceClause?.description.trimmingCharacters(in: .whitespaces) ?? ""
+                        type.inheritanceClause?.description
+                            .trimmingCharacters(in: .whitespaces) ?? ""
                     })
                 }
 
-                let hasConflictingConstraints = constraintSetsByTypeName.values.contains { constraints in
-                    constraints.count > 1
-                }
+                let hasConflictingConstraints = constraintSetsByTypeName.values
+                    .contains { constraints in
+                        constraints.count > 1
+                    }
                 return hasConflictingConstraints ? clauses : nil
             }
             .first
@@ -790,7 +801,8 @@ extension MockedMacro {
             clauses: IfConfigClauseListSyntax(
                 clauses.enumerated().map { index, clause in
                     IfConfigClauseSyntax(
-                        poundKeyword: index == 0 ? .poundIfToken()
+                        poundKeyword: index == 0
+                            ? .poundIfToken()
                             : clause.condition != nil ? .poundElseifToken() : .poundElseToken(),
                         condition: clause.condition,
                         elements: .decls(MemberBlockItemListSyntax {
@@ -810,7 +822,7 @@ extension MockedMacro {
 
         let declarations: [DeclSyntax] = [
             DeclSyntax(mockDeclaration),
-            DeclSyntax(ifConfigDeclaration)
+            DeclSyntax(ifConfigDeclaration),
         ]
 
         guard let condition = macroArguments.compilationCondition.rawValue else {
@@ -861,7 +873,10 @@ extension MockedMacro {
     private static func whereClause(
         from associatedTypes: [AssociatedTypeDeclSyntax]
     ) -> GenericWhereClauseSyntax? {
-        let allConstraints = associatedTypes.flatMap { associatedType -> [(name: TokenSyntax, type: TypeSyntax)] in
+        let allConstraints = associatedTypes.flatMap { associatedType -> [(
+            name: TokenSyntax,
+            type: TypeSyntax
+        )] in
             guard let inheritanceClause = associatedType.inheritanceClause else {
                 return []
             }
@@ -877,8 +892,10 @@ extension MockedMacro {
                     TypeSyntax(compositionType.type)
                 }
 
-
-            return (identifierTypes + compositionTypes).map { type in (associatedType.name.trimmed, type) }
+            return (identifierTypes + compositionTypes).map { type in (
+                associatedType.name.trimmed,
+                type
+            ) }
         }
 
         guard !allConstraints.isEmpty else {

--- a/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
+++ b/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
@@ -121,7 +121,8 @@ extension MockedMacro {
     /// generated from the associated types defined by the provided protocol.
     ///
     /// The clause supports associated types with comma-separated constraints,
-    /// composition (`&`), or a combination of both.
+    /// composition (`&`), or a combination of both. Associated types inside
+    /// `#if` blocks are also extracted.
     ///
     /// ```swift
     /// @Mocked
@@ -140,16 +141,25 @@ extension MockedMacro {
         from protocolDeclaration: ProtocolDeclSyntax
     ) -> GenericParameterClauseSyntax? {
         let memberBlock = protocolDeclaration.memberBlock
-        let associatedTypeDeclarations = memberBlock.memberDeclarations(
-            ofType: AssociatedTypeDeclSyntax.self
-        )
+        let associatedTypeDeclarations = self.collectAssociatedTypes(from: memberBlock)
 
         guard !associatedTypeDeclarations.isEmpty else {
             return nil
         }
 
+        // Deduplicate by name (same associated type may appear in multiple #if branches)
+        var seenNames: Set<String> = []
+        let uniqueAssociatedTypes = associatedTypeDeclarations.filter { decl in
+            let name = decl.name.text
+            if seenNames.contains(name) {
+                return false
+            }
+            seenNames.insert(name)
+            return true
+        }
+
         return GenericParameterClauseSyntax {
-            for associatedTypeDeclaration in associatedTypeDeclarations {
+            for associatedTypeDeclaration in uniqueAssociatedTypes {
                 let genericParameterName = associatedTypeDeclaration.name.trimmed
 
                 if let inheritanceClause = associatedTypeDeclaration.inheritanceClause {
@@ -181,6 +191,55 @@ extension MockedMacro {
                 }
             }
         }
+    }
+
+    /// Collects all associated type declarations from a member block, including
+    /// those inside `#if` blocks.
+    ///
+    /// - Parameter memberBlock: The member block to search.
+    /// - Returns: An array of associated type declarations.
+    private static func collectAssociatedTypes(
+        from memberBlock: MemberBlockSyntax
+    ) -> [AssociatedTypeDeclSyntax] {
+        var associatedTypes: [AssociatedTypeDeclSyntax] = []
+
+        for member in memberBlock.members {
+            if let associatedType = member.decl.as(AssociatedTypeDeclSyntax.self) {
+                associatedTypes.append(associatedType)
+            } else if let ifConfigDecl = member.decl.as(IfConfigDeclSyntax.self) {
+                associatedTypes.append(contentsOf: self.collectAssociatedTypes(from: ifConfigDecl))
+            }
+        }
+
+        return associatedTypes
+    }
+
+    /// Collects all associated type declarations from an `IfConfigDeclSyntax`,
+    /// searching all branches.
+    ///
+    /// - Parameter ifConfigDecl: The `#if` declaration to search.
+    /// - Returns: An array of associated type declarations.
+    private static func collectAssociatedTypes(
+        from ifConfigDecl: IfConfigDeclSyntax
+    ) -> [AssociatedTypeDeclSyntax] {
+        var associatedTypes: [AssociatedTypeDeclSyntax] = []
+
+        for clause in ifConfigDecl.clauses {
+            guard case let .decls(members) = clause.elements else {
+                continue
+            }
+
+            for member in members {
+                if let associatedType = member.decl.as(AssociatedTypeDeclSyntax.self) {
+                    associatedTypes.append(associatedType)
+                } else if let nestedIfConfig = member.decl.as(IfConfigDeclSyntax.self) {
+                    associatedTypes
+                        .append(contentsOf: self.collectAssociatedTypes(from: nestedIfConfig))
+                }
+            }
+        }
+
+        return associatedTypes
     }
 
     // MARK: Inheritance Clause
@@ -265,6 +324,17 @@ extension MockedMacro {
         let methodDeclarations = memberBlock.memberDeclarations(
             ofType: FunctionDeclSyntax.self
         )
+        let ifConfigDeclarations = memberBlock.memberDeclarations(
+            ofType: IfConfigDeclSyntax.self
+        )
+
+        let mockedIfConfigDeclarations: [IfConfigDeclSyntax] = try ifConfigDeclarations.compactMap {
+            try self.mockIfConfigDeclaration(
+                from: $0,
+                with: accessLevel,
+                in: protocolDeclaration
+            )
+        }
 
         return try MemberBlockSyntax {
             for initializerDeclaration in initializerDeclarations {
@@ -290,6 +360,10 @@ extension MockedMacro {
                     for: methodDeclaration,
                     in: protocolDeclaration
                 )
+            }
+
+            for mockedIfConfig in mockedIfConfigDeclarations {
+                mockedIfConfig
             }
         }
     }
@@ -528,5 +602,116 @@ extension MockedMacro {
                 modifier.trimmed
             }
         }
+    }
+
+    // MARK: Conditional Compilation
+
+    /// Returns an `IfConfigDeclSyntax` containing mocked member declarations,
+    /// preserving the conditional compilation structure from the protocol.
+    ///
+    /// - Parameters:
+    ///   - ifConfigDecl: The `IfConfigDeclSyntax` from the protocol containing
+    ///     member declarations.
+    ///   - accessLevel: The access level to apply to the mocked declarations.
+    ///   - protocolDeclaration: The protocol being mocked.
+    /// - Returns: An `IfConfigDeclSyntax` with mocked member declarations,
+    ///   or `nil` if all clauses are empty (e.g., only contained associated types).
+    private static func mockIfConfigDeclaration(
+        from ifConfigDecl: IfConfigDeclSyntax,
+        with accessLevel: AccessLevelSyntax,
+        in protocolDeclaration: ProtocolDeclSyntax
+    ) throws -> IfConfigDeclSyntax? {
+        let transformedClauses = try IfConfigClauseListSyntax {
+            for clause in ifConfigDecl.clauses {
+                try self.mockIfConfigClause(
+                    from: clause,
+                    with: accessLevel,
+                    in: protocolDeclaration
+                )
+            }
+        }
+
+        let allClausesEmpty = transformedClauses.allSatisfy { clause in
+            guard case let .decls(members) = clause.elements else {
+                return true
+            }
+            return members.isEmpty
+        }
+
+        guard !allClausesEmpty else {
+            return nil
+        }
+
+        return IfConfigDeclSyntax(
+            clauses: transformedClauses,
+            poundEndif: ifConfigDecl.poundEndif.trimmed
+        )
+    }
+
+    /// Returns a transformed `IfConfigClauseSyntax` with mocked member declarations.
+    ///
+    /// Associated types are skipped since they become generic parameters on the
+    /// mock class rather than member declarations.
+    ///
+    /// - Parameters:
+    ///   - clause: The clause to transform.
+    ///   - accessLevel: The access level to apply to the mocked declarations.
+    ///   - protocolDeclaration: The protocol being mocked.
+    /// - Returns: A transformed `IfConfigClauseSyntax`.
+    private static func mockIfConfigClause(
+        from clause: IfConfigClauseSyntax,
+        with accessLevel: AccessLevelSyntax,
+        in protocolDeclaration: ProtocolDeclSyntax
+    ) throws -> IfConfigClauseSyntax {
+        guard case let .decls(memberBlockItems) = clause.elements else {
+            return clause
+        }
+
+        let transformedMembers = try MemberBlockItemListSyntax {
+            for member in memberBlockItems {
+                if let initializerDecl = member.decl.as(InitializerDeclSyntax.self) {
+                    MemberBlockItemSyntax(
+                        decl: try self.mockInitializerConformanceDeclaration(
+                            with: accessLevel,
+                            from: initializerDecl
+                        )
+                    )
+                } else if let propertyDecl = member.decl.as(VariableDeclSyntax.self) {
+                    for binding in propertyDecl.bindings {
+                        MemberBlockItemSyntax(
+                            decl: try self.mockPropertyConformanceDeclaration(
+                                with: accessLevel,
+                                for: binding,
+                                from: propertyDecl
+                            )
+                        )
+                    }
+                } else if let methodDecl = member.decl.as(FunctionDeclSyntax.self) {
+                    MemberBlockItemSyntax(
+                        decl: try self.mockMethodConformanceDeclaration(
+                            with: accessLevel,
+                            for: methodDecl,
+                            in: protocolDeclaration
+                        )
+                    )
+                } else if let nestedIfConfig = member.decl.as(IfConfigDeclSyntax.self) {
+                    if let mockedIfConfig = try self.mockIfConfigDeclaration(
+                        from: nestedIfConfig,
+                        with: accessLevel,
+                        in: protocolDeclaration
+                    ) {
+                        MemberBlockItemSyntax(decl: mockedIfConfig)
+                    }
+                }
+                // AssociatedTypeDeclSyntax is intentionally skipped here since
+                // associated types become generic parameters on the mock class.
+            }
+        }
+
+        return IfConfigClauseSyntax(
+            poundKeyword: clause.poundKeyword.trimmed,
+            condition: clause.condition?.trimmed,
+            elements: .decls(transformedMembers)
+        )
     }
 }

--- a/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
+++ b/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
@@ -32,13 +32,13 @@ public struct MockedMacro: PeerMacro {
             from: protocolDeclaration,
             macroArguments: macroArguments,
             mockName: mockName,
-            mockGenericParameterClause: mockGenericSpecialization.mockGenericParameterClause,
-            mockGenericWhereClause: mockGenericSpecialization.mockGenericWhereClause,
-            shouldMockConformToProtocol: mockGenericSpecialization.mockPeerIfConfigDeclarations.isEmpty
+            mockGenericParameterClause: mockGenericSpecialization.genericParameterClause,
+            mockGenericWhereClause: mockGenericSpecialization.genericWhereClause,
+            shouldMockConformToProtocol: mockGenericSpecialization.peerIfConfigDeclarations.isEmpty
         )
 
         let declarations = [DeclSyntax(mockDeclaration)]
-            + mockGenericSpecialization.mockPeerIfConfigDeclarations.map(DeclSyntax.init)
+            + mockGenericSpecialization.peerIfConfigDeclarations.map(DeclSyntax.init)
 
         guard let compilationCondition = macroArguments.compilationCondition.rawValue else {
             return declarations
@@ -171,9 +171,9 @@ extension MockedMacro {
         mockName: TokenSyntax,
         protocolDeclaration: ProtocolDeclSyntax
     ) -> (
-        mockGenericParameterClause: GenericParameterClauseSyntax?,
-        mockGenericWhereClause: GenericWhereClauseSyntax?,
-        mockPeerIfConfigDeclarations: [IfConfigDeclSyntax]
+        genericParameterClause: GenericParameterClauseSyntax?,
+        genericWhereClause: GenericWhereClauseSyntax?,
+        peerIfConfigDeclarations: [IfConfigDeclSyntax]
     ) {
         let protocolGenericRequirements = protocolDeclaration.genericWhereClause?.requirements
 

--- a/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
+++ b/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
@@ -297,72 +297,74 @@ extension MockedMacro {
     // MARK: Members
 
     /// Returns the member block to apply to the mock, generated from the
-    /// properties and methods of the provided protocol.
+    /// members from the provided `protocolDeclaration`.
     ///
-    /// - Parameter protocolDeclaration: The protocol to which the mock must
-    ///   conform.
+    /// - Parameter protocolDeclaration: The protocol being mocked.
     /// - Returns: The member block to apply to the mock.
     private static func mockMemberBlock(
         from protocolDeclaration: ProtocolDeclSyntax
     ) throws -> MemberBlockSyntax {
         let accessLevel = protocolDeclaration.minimumConformingAccessLevel
-        let transformedMembers = try self.mockMemberBlockItems(
+        let members = try self.mockMembers(
             from: protocolDeclaration.memberBlock.members,
             with: accessLevel,
             in: protocolDeclaration
         )
-        return MemberBlockSyntax(members: transformedMembers)
+
+        return MemberBlockSyntax(members: members)
     }
 
-    /// Transforms member block items into mocked declarations.
+    /// Returns the members to apply to the mock, generated from the provided
+    /// `members` from the provided `protocolDeclaration` and marked with the
+    /// provided `accessLevel`.
     ///
-    /// Associated types are skipped since they become generic parameters on the
-    /// mock class rather than member declarations.
+    /// Associated types are skipped since they become generic parameters for
+    /// the mock class rather than member declarations.
     ///
     /// - Parameters:
-    ///   - members: The member block items to transform.
-    ///   - accessLevel: The access level to apply to the mocked declarations.
+    ///   - members: The members from the protocol being mocked.
+    ///   - accessLevel: The access level to apply to the mock's members.
     ///   - protocolDeclaration: The protocol being mocked.
-    /// - Returns: The transformed member block items.
-    private static func mockMemberBlockItems(
+    /// - Returns: The members to apply to the mock.
+    private static func mockMembers(
         from members: MemberBlockItemListSyntax,
         with accessLevel: AccessLevelSyntax,
         in protocolDeclaration: ProtocolDeclSyntax
     ) throws -> MemberBlockItemListSyntax {
         try MemberBlockItemListSyntax {
             for member in members {
-                if let initializerDecl = member.decl.as(InitializerDeclSyntax.self) {
+                if let initializerDeclaration = member.decl.as(InitializerDeclSyntax.self) {
                     MemberBlockItemSyntax(
                         decl: try self.mockInitializerConformanceDeclaration(
                             with: accessLevel,
-                            from: initializerDecl
+                            from: initializerDeclaration
                         )
                     )
-                } else if let propertyDecl = member.decl.as(VariableDeclSyntax.self) {
-                    for binding in propertyDecl.bindings {
+                } else if let propertyDeclaration = member.decl.as(VariableDeclSyntax.self) {
+                    for binding in propertyDeclaration.bindings {
                         MemberBlockItemSyntax(
                             decl: try self.mockPropertyConformanceDeclaration(
                                 with: accessLevel,
                                 for: binding,
-                                from: propertyDecl
+                                from: propertyDeclaration
                             )
                         )
                     }
-                } else if let methodDecl = member.decl.as(FunctionDeclSyntax.self) {
+                } else if let methodDeclaration = member.decl.as(FunctionDeclSyntax.self) {
                     MemberBlockItemSyntax(
                         decl: try self.mockMethodConformanceDeclaration(
                             with: accessLevel,
-                            for: methodDecl,
+                            for: methodDeclaration,
                             in: protocolDeclaration
                         )
                     )
-                } else if let ifConfigDecl = member.decl.as(IfConfigDeclSyntax.self) {
-                    if let mockedIfConfig = try self.mockIfConfigDeclaration(
-                        from: ifConfigDecl,
+                } else if let ifConfigDeclaration = member.decl.as(IfConfigDeclSyntax.self) {
+                    if let mockIfConfigDeclaration = try self.mockIfConfigDeclaration(
+                        from: ifConfigDeclaration,
                         with: accessLevel,
                         in: protocolDeclaration
                     ) {
-                        MemberBlockItemSyntax(decl: mockedIfConfig)
+                        MemberBlockItemSyntax(decl: mockIfConfigDeclaration)
                     }
                 }
             }
@@ -543,6 +545,65 @@ extension MockedMacro {
             }
     }
 
+    // MARK: If Configs
+
+    /// Returns an `IfConfigDeclSyntax` containing mock member declarations,
+    /// generated from the provided `ifConfigDeclaration` from the provided
+    /// `protocolDeclaration` and marked with the provided `accessLevel`.
+    ///
+    /// This method preserves the conditional compilation structure from the
+    /// provided `ifConfigDeclaration` in the returned `IfConfigDeclSyntax`.
+    ///
+    /// - Parameters:
+    ///   - ifConfigDeclaration: The `IfConfigDeclSyntax` from the protocol.
+    ///   - accessLevel: The access level to apply to the mock declarations.
+    ///   - protocolDeclaration: The protocol being mocked.
+    /// - Returns: An `IfConfigDeclSyntax` containing mock member declarations,
+    ///   or `nil` if none of the clauses contain member declarations (e.g., are
+    ///   empty or contain only associated type declarations).
+    private static func mockIfConfigDeclaration(
+        from ifConfigDeclaration: IfConfigDeclSyntax,
+        with accessLevel: AccessLevelSyntax,
+        in protocolDeclaration: ProtocolDeclSyntax
+    ) throws -> IfConfigDeclSyntax? {
+        let clauses = try IfConfigClauseListSyntax(
+            ifConfigDeclaration.clauses.map { clause in
+                guard case let .decls(members) = clause.elements else {
+                    return clause
+                }
+
+                let mockMembers = try self.mockMembers(
+                    from: members,
+                    with: accessLevel,
+                    in: protocolDeclaration
+                )
+
+                return IfConfigClauseSyntax(
+                    poundKeyword: clause.poundKeyword.trimmed,
+                    condition: clause.condition?.trimmed,
+                    elements: .decls(mockMembers)
+                )
+            }
+        )
+
+        let allClausesEmpty = clauses.allSatisfy { clause in
+            guard case let .decls(members) = clause.elements else {
+                return true
+            }
+
+            return members.isEmpty
+        }
+
+        guard !allClausesEmpty else {
+            return nil
+        }
+
+        return IfConfigDeclSyntax(
+            clauses: clauses,
+            poundEndif: ifConfigDeclaration.poundEndif.trimmed
+        )
+    }
+
     // MARK: Modifiers
 
     /// Returns modifiers to apply to override declarations, generated using the
@@ -603,59 +664,5 @@ extension MockedMacro {
                 modifier.trimmed
             }
         }
-    }
-
-    // MARK: Conditional Compilation
-
-    /// Returns an `IfConfigDeclSyntax` containing mocked member declarations,
-    /// preserving the conditional compilation structure from the protocol.
-    ///
-    /// - Parameters:
-    ///   - ifConfigDecl: The `IfConfigDeclSyntax` from the protocol containing
-    ///     member declarations.
-    ///   - accessLevel: The access level to apply to the mocked declarations.
-    ///   - protocolDeclaration: The protocol being mocked.
-    /// - Returns: An `IfConfigDeclSyntax` with mocked member declarations,
-    ///   or `nil` if all clauses are empty (e.g., only contained associated types).
-    private static func mockIfConfigDeclaration(
-        from ifConfigDecl: IfConfigDeclSyntax,
-        with accessLevel: AccessLevelSyntax,
-        in protocolDeclaration: ProtocolDeclSyntax
-    ) throws -> IfConfigDeclSyntax? {
-        let transformedClauses = try IfConfigClauseListSyntax(
-            ifConfigDecl.clauses.map { clause in
-                guard case let .decls(memberBlockItems) = clause.elements else {
-                    return clause
-                }
-
-                let transformedMembers = try self.mockMemberBlockItems(
-                    from: memberBlockItems,
-                    with: accessLevel,
-                    in: protocolDeclaration
-                )
-
-                return IfConfigClauseSyntax(
-                    poundKeyword: clause.poundKeyword.trimmed,
-                    condition: clause.condition?.trimmed,
-                    elements: .decls(transformedMembers)
-                )
-            }
-        )
-
-        let allClausesEmpty = transformedClauses.allSatisfy { clause in
-            guard case let .decls(members) = clause.elements else {
-                return true
-            }
-            return members.isEmpty
-        }
-
-        guard !allClausesEmpty else {
-            return nil
-        }
-
-        return IfConfigDeclSyntax(
-            clauses: transformedClauses,
-            poundEndif: ifConfigDecl.poundEndif.trimmed
-        )
     }
 }

--- a/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
+++ b/Sources/MockingMacros/Macros/MockedMacro/MockedMacro.swift
@@ -191,7 +191,9 @@ extension MockedMacro {
 
                 self.appendGenericParameter(mockGenericParameter, to: &mockGenericParameters)
 
-                if let associatedTypeGenericWhereClause = associatedTypeDeclaration.genericWhereClause {
+                if let associatedTypeGenericWhereClause = associatedTypeDeclaration
+                    .genericWhereClause
+                {
                     mockGenericWhereClauseRequirements.append(
                         contentsOf: associatedTypeGenericWhereClause.requirements.map(
                             \.requirement
@@ -289,7 +291,9 @@ extension MockedMacro {
                         )
                     }
 
-                    if let associatedTypeGenericWhereClause = associatedTypeDeclaration.genericWhereClause {
+                    if let associatedTypeGenericWhereClause = associatedTypeDeclaration
+                        .genericWhereClause
+                    {
                         mockExtensionGenericWhereClauseRequirements.append(
                             contentsOf: associatedTypeGenericWhereClause.requirements.map(
                                 \.requirement

--- a/Tests/MockingMacrosTests/Macros/MockedMacro/Mocked_IfConfigDeclTests.swift
+++ b/Tests/MockingMacrosTests/Macros/MockedMacro/Mocked_IfConfigDeclTests.swift
@@ -8,8 +8,139 @@
 import Testing
 @testable import MockingMacros
 
-/// Tests for IfConfigDeclSyntax support in mocked protocols.
 struct Mocked_IfConfigDeclTests {
+
+    // MARK: Initializer in #if Block Tests
+
+    @Test(arguments: mockedTestConfigurations)
+    func initializerInIfBlock(
+        interface: InterfaceConfiguration,
+        mock: MockConfiguration
+    ) {
+        assertMocked(
+            """
+            \(interface.accessLevel) protocol Dependency {
+                init()
+                #if DEBUG
+                init(debugParameter: String)
+                #endif
+            }
+            """,
+            generates: """
+            #if SWIFT_MOCKING_ENABLED
+            @MockedMembers
+            \(mock.modifiers)class DependencyMock: Dependency {
+                \(mock.memberModifiers)init() {
+                }
+                #if DEBUG
+                \(mock.memberModifiers)init(debugParameter: String) {
+                }
+                #endif
+            }
+            #endif
+            """
+        )
+    }
+
+    // MARK: Initializer in #if/#else Block Tests
+
+    @Test(arguments: mockedTestConfigurations)
+    func initializerInIfElseBlock(
+        interface: InterfaceConfiguration,
+        mock: MockConfiguration
+    ) {
+        assertMocked(
+            """
+            \(interface.accessLevel) protocol Dependency {
+                #if os(iOS)
+                init(iOSParameter: String)
+                #else
+                init(otherPlatformParameter: String)
+                #endif
+            }
+            """,
+            generates: """
+            #if SWIFT_MOCKING_ENABLED
+            @MockedMembers
+            \(mock.modifiers)class DependencyMock: Dependency {
+                #if os(iOS)
+                \(mock.memberModifiers)init(iOSParameter: String) {
+                }
+                #else
+                \(mock.memberModifiers)init(otherPlatformParameter: String) {
+                }
+                #endif
+            }
+            #endif
+            """
+        )
+    }
+
+    // MARK: Property in #if Block Tests
+
+    @Test(arguments: mockedTestConfigurations)
+    func propertyInIfBlock(
+        interface: InterfaceConfiguration,
+        mock: MockConfiguration
+    ) {
+        assertMocked(
+            """
+            \(interface.accessLevel) protocol Dependency {
+                var commonProperty: String { get }
+                #if DEBUG
+                var debugProperty: Int { get set }
+                #endif
+            }
+            """,
+            generates: """
+            #if SWIFT_MOCKING_ENABLED
+            @MockedMembers
+            \(mock.modifiers)class DependencyMock: Dependency {
+                @MockableProperty(.readOnly)
+                \(mock.memberModifiers)var commonProperty: String
+                #if DEBUG
+                @MockableProperty(.readWrite)
+                \(mock.memberModifiers)var debugProperty: Int
+                #endif
+            }
+            #endif
+            """
+        )
+    }
+
+    // MARK: Property in #if/#else Block Tests
+
+    @Test(arguments: mockedTestConfigurations)
+    func propertyInIfElseBlock(
+        interface: InterfaceConfiguration,
+        mock: MockConfiguration
+    ) {
+        assertMocked(
+            """
+            \(interface.accessLevel) protocol Dependency {
+                #if os(iOS)
+                var iOSProperty: String { get }
+                #else
+                var otherPlatformProperty: Int { get set }
+                #endif
+            }
+            """,
+            generates: """
+            #if SWIFT_MOCKING_ENABLED
+            @MockedMembers
+            \(mock.modifiers)class DependencyMock: Dependency {
+                #if os(iOS)
+                @MockableProperty(.readOnly)
+                \(mock.memberModifiers)var iOSProperty: String
+                #else
+                @MockableProperty(.readWrite)
+                \(mock.memberModifiers)var otherPlatformProperty: Int
+                #endif
+            }
+            #endif
+            """
+        )
+    }
 
     // MARK: Method in #if Block Tests
 
@@ -66,70 +197,6 @@ struct Mocked_IfConfigDeclTests {
                 \(mock.memberModifiers)func iOSMethod()
                 #else
                 \(mock.memberModifiers)func otherPlatformMethod()
-                #endif
-            }
-            #endif
-            """
-        )
-    }
-
-    // MARK: Property in #if Block Tests
-
-    @Test(arguments: mockedTestConfigurations)
-    func propertyInIfBlock(
-        interface: InterfaceConfiguration,
-        mock: MockConfiguration
-    ) {
-        assertMocked(
-            """
-            \(interface.accessLevel) protocol Dependency {
-                var commonProperty: String { get }
-                #if DEBUG
-                var debugProperty: Int { get set }
-                #endif
-            }
-            """,
-            generates: """
-            #if SWIFT_MOCKING_ENABLED
-            @MockedMembers
-            \(mock.modifiers)class DependencyMock: Dependency {
-                @MockableProperty(.readOnly)
-                \(mock.memberModifiers)var commonProperty: String
-                #if DEBUG
-                @MockableProperty(.readWrite)
-                \(mock.memberModifiers)var debugProperty: Int
-                #endif
-            }
-            #endif
-            """
-        )
-    }
-
-    // MARK: Initializer in #if Block Tests
-
-    @Test(arguments: mockedTestConfigurations)
-    func initializerInIfBlock(
-        interface: InterfaceConfiguration,
-        mock: MockConfiguration
-    ) {
-        assertMocked(
-            """
-            \(interface.accessLevel) protocol Dependency {
-                init()
-                #if DEBUG
-                init(debugParameter: String)
-                #endif
-            }
-            """,
-            generates: """
-            #if SWIFT_MOCKING_ENABLED
-            @MockedMembers
-            \(mock.modifiers)class DependencyMock: Dependency {
-                \(mock.memberModifiers)init() {
-                }
-                #if DEBUG
-                \(mock.memberModifiers)init(debugParameter: String) {
-                }
                 #endif
             }
             #endif

--- a/Tests/MockingMacrosTests/Macros/MockedMacro/Mocked_IfConfigDeclTests.swift
+++ b/Tests/MockingMacrosTests/Macros/MockedMacro/Mocked_IfConfigDeclTests.swift
@@ -230,5 +230,69 @@ struct Mocked_IfConfigDeclTests {
             """
         )
     }
+
+    // MARK: OR Condition Tests
+
+    @Test(arguments: mockedTestConfigurations)
+    func orCondition(
+        interface: InterfaceConfiguration,
+        mock: MockConfiguration
+    ) {
+        assertMocked(
+            """
+            \(interface.accessLevel) protocol Dependency {
+                func commonMethod()
+                #if DEBUG || TESTFLIGHT
+                func debugOrTestFlightMethod()
+                #endif
+            }
+            """,
+            generates: """
+            #if SWIFT_MOCKING_ENABLED
+            @MockedMembers
+            \(mock.modifiers)class DependencyMock: Dependency {
+                \(mock.memberModifiers)func commonMethod()
+                #if DEBUG || TESTFLIGHT
+                \(mock.memberModifiers)func debugOrTestFlightMethod()
+                #endif
+            }
+            #endif
+            """
+        )
+    }
+
+    // MARK: Nested #if Conditional Tests
+
+    @Test(arguments: mockedTestConfigurations)
+    func nestedIfConditionals(
+        interface: InterfaceConfiguration,
+        mock: MockConfiguration
+    ) {
+        assertMocked(
+            """
+            \(interface.accessLevel) protocol Dependency {
+                #if DEBUG
+                func debugMethod()
+                #if os(iOS)
+                func debugiOSOnlyMethod()
+                #endif
+                #endif
+            }
+            """,
+            generates: """
+            #if SWIFT_MOCKING_ENABLED
+            @MockedMembers
+            \(mock.modifiers)class DependencyMock: Dependency {
+                #if DEBUG
+                \(mock.memberModifiers)func debugMethod()
+                #if os(iOS)
+                \(mock.memberModifiers)func debugiOSOnlyMethod()
+                #endif
+                #endif
+            }
+            #endif
+            """
+        )
+    }
 }
 #endif

--- a/Tests/MockingMacrosTests/Macros/MockedMacro/Mocked_IfConfigDeclTests.swift
+++ b/Tests/MockingMacrosTests/Macros/MockedMacro/Mocked_IfConfigDeclTests.swift
@@ -1,0 +1,234 @@
+//
+//  Mocked_IfConfigDeclTests.swift
+//
+//  Copyright © 2026 Fetch.
+//
+
+#if canImport(MockingMacros)
+import Testing
+@testable import MockingMacros
+
+/// Tests for IfConfigDeclSyntax support in mocked protocols.
+struct Mocked_IfConfigDeclTests {
+
+    // MARK: Method in #if Block Tests
+
+    @Test(arguments: mockedTestConfigurations)
+    func methodInIfBlock(
+        interface: InterfaceConfiguration,
+        mock: MockConfiguration
+    ) {
+        assertMocked(
+            """
+            \(interface.accessLevel) protocol Dependency {
+                func commonMethod()
+                #if DEBUG
+                func debugOnlyMethod()
+                #endif
+            }
+            """,
+            generates: """
+            #if SWIFT_MOCKING_ENABLED
+            @MockedMembers
+            \(mock.modifiers)class DependencyMock: Dependency {
+                \(mock.memberModifiers)func commonMethod()
+                #if DEBUG
+                \(mock.memberModifiers)func debugOnlyMethod()
+                #endif
+            }
+            #endif
+            """
+        )
+    }
+
+    // MARK: Method in #if/#else Block Tests
+
+    @Test(arguments: mockedTestConfigurations)
+    func methodInIfElseBlock(
+        interface: InterfaceConfiguration,
+        mock: MockConfiguration
+    ) {
+        assertMocked(
+            """
+            \(interface.accessLevel) protocol Dependency {
+                #if os(iOS)
+                func iOSMethod()
+                #else
+                func otherPlatformMethod()
+                #endif
+            }
+            """,
+            generates: """
+            #if SWIFT_MOCKING_ENABLED
+            @MockedMembers
+            \(mock.modifiers)class DependencyMock: Dependency {
+                #if os(iOS)
+                \(mock.memberModifiers)func iOSMethod()
+                #else
+                \(mock.memberModifiers)func otherPlatformMethod()
+                #endif
+            }
+            #endif
+            """
+        )
+    }
+
+    // MARK: Property in #if Block Tests
+
+    @Test(arguments: mockedTestConfigurations)
+    func propertyInIfBlock(
+        interface: InterfaceConfiguration,
+        mock: MockConfiguration
+    ) {
+        assertMocked(
+            """
+            \(interface.accessLevel) protocol Dependency {
+                var commonProperty: String { get }
+                #if DEBUG
+                var debugProperty: Int { get set }
+                #endif
+            }
+            """,
+            generates: """
+            #if SWIFT_MOCKING_ENABLED
+            @MockedMembers
+            \(mock.modifiers)class DependencyMock: Dependency {
+                @MockableProperty(.readOnly)
+                \(mock.memberModifiers)var commonProperty: String
+                #if DEBUG
+                @MockableProperty(.readWrite)
+                \(mock.memberModifiers)var debugProperty: Int
+                #endif
+            }
+            #endif
+            """
+        )
+    }
+
+    // MARK: Initializer in #if Block Tests
+
+    @Test(arguments: mockedTestConfigurations)
+    func initializerInIfBlock(
+        interface: InterfaceConfiguration,
+        mock: MockConfiguration
+    ) {
+        assertMocked(
+            """
+            \(interface.accessLevel) protocol Dependency {
+                init()
+                #if DEBUG
+                init(debugParameter: String)
+                #endif
+            }
+            """,
+            generates: """
+            #if SWIFT_MOCKING_ENABLED
+            @MockedMembers
+            \(mock.modifiers)class DependencyMock: Dependency {
+                \(mock.memberModifiers)init() {
+                }
+                #if DEBUG
+                \(mock.memberModifiers)init(debugParameter: String) {
+                }
+                #endif
+            }
+            #endif
+            """
+        )
+    }
+
+    // MARK: Multiple Members in #if Block Tests
+
+    @Test(arguments: mockedTestConfigurations)
+    func multipleMembersInIfBlock(
+        interface: InterfaceConfiguration,
+        mock: MockConfiguration
+    ) {
+        assertMocked(
+            """
+            \(interface.accessLevel) protocol Dependency {
+                #if DEBUG
+                var debugProperty: Int { get }
+                func debugMethod()
+                #endif
+            }
+            """,
+            generates: """
+            #if SWIFT_MOCKING_ENABLED
+            @MockedMembers
+            \(mock.modifiers)class DependencyMock: Dependency {
+                #if DEBUG
+                @MockableProperty(.readOnly)
+                \(mock.memberModifiers)var debugProperty: Int
+                \(mock.memberModifiers)func debugMethod()
+                #endif
+            }
+            #endif
+            """
+        )
+    }
+
+    // MARK: #if/#elseif/#else Chain Tests
+
+    @Test(arguments: mockedTestConfigurations)
+    func ifElseifElseChain(
+        interface: InterfaceConfiguration,
+        mock: MockConfiguration
+    ) {
+        assertMocked(
+            """
+            \(interface.accessLevel) protocol Dependency {
+                #if os(iOS)
+                func iOSMethod()
+                #elseif os(macOS)
+                func macOSMethod()
+                #else
+                func otherMethod()
+                #endif
+            }
+            """,
+            generates: """
+            #if SWIFT_MOCKING_ENABLED
+            @MockedMembers
+            \(mock.modifiers)class DependencyMock: Dependency {
+                #if os(iOS)
+                \(mock.memberModifiers)func iOSMethod()
+                #elseif os(macOS)
+                \(mock.memberModifiers)func macOSMethod()
+                #else
+                \(mock.memberModifiers)func otherMethod()
+                #endif
+            }
+            #endif
+            """
+        )
+    }
+
+    // MARK: Associated Type in #if Block Tests
+
+    @Test(arguments: mockedTestConfigurations)
+    func associatedTypeInIfBlock(
+        interface: InterfaceConfiguration,
+        mock: MockConfiguration
+    ) {
+        assertMocked(
+            """
+            \(interface.accessLevel) protocol Dependency {
+                #if os(iOS)
+                associatedtype PlatformView
+                #else
+                associatedtype PlatformView
+                #endif
+            }
+            """,
+            generates: """
+            #if SWIFT_MOCKING_ENABLED
+            @MockedMembers
+            \(mock.modifiers)class DependencyMock<PlatformView>: Dependency {
+            }
+            #endif
+            """
+        )
+    }
+}
+#endif

--- a/Tests/MockingMacrosTests/Macros/MockedMacro/Mocked_IfConfigDeclTests.swift
+++ b/Tests/MockingMacrosTests/Macros/MockedMacro/Mocked_IfConfigDeclTests.swift
@@ -298,6 +298,109 @@ struct Mocked_IfConfigDeclTests {
         )
     }
 
+    // MARK: Associated Type with Different Constraints in #if/#else Tests
+
+    @Test(arguments: mockedTestConfigurations)
+    func associatedTypeWithDifferentConstraintsInIfElseBlock(
+        interface: InterfaceConfiguration,
+        mock: MockConfiguration
+    ) {
+        assertMocked(
+            """
+            \(interface.accessLevel) protocol SomeCollection {
+                #if DEBUG
+                associatedtype Item: Equatable
+                #else
+                associatedtype Item: Hashable
+                #endif
+            }
+            """,
+            generates: """
+            #if SWIFT_MOCKING_ENABLED
+            @MockedMembers
+            \(mock.modifiers)class SomeCollectionMock<Item> {
+            }
+            #if DEBUG
+            extension SomeCollectionMock: SomeCollection where Item: Equatable {
+            }
+            #else
+            extension SomeCollectionMock: SomeCollection where Item: Hashable {
+            }
+            #endif
+            #endif
+            """
+        )
+    }
+
+    @Test(arguments: mockedTestConfigurations)
+    func associatedTypeWithDifferentConstraintsInIfElseifElseChain(
+        interface: InterfaceConfiguration,
+        mock: MockConfiguration
+    ) {
+        assertMocked(
+            """
+            \(interface.accessLevel) protocol PlatformCollection {
+                #if os(iOS)
+                associatedtype Element: Equatable
+                #elseif os(macOS)
+                associatedtype Element: Hashable
+                #else
+                associatedtype Element: Codable
+                #endif
+            }
+            """,
+            generates: """
+            #if SWIFT_MOCKING_ENABLED
+            @MockedMembers
+            \(mock.modifiers)class PlatformCollectionMock<Element> {
+            }
+            #if os(iOS)
+            extension PlatformCollectionMock: PlatformCollection where Element: Equatable {
+            }
+            #elseif os(macOS)
+            extension PlatformCollectionMock: PlatformCollection where Element: Hashable {
+            }
+            #else
+            extension PlatformCollectionMock: PlatformCollection where Element: Codable {
+            }
+            #endif
+            #endif
+            """
+        )
+    }
+
+    @Test(arguments: mockedTestConfigurations)
+    func associatedTypeWithMultipleConstraintsInIfElseBlock(
+        interface: InterfaceConfiguration,
+        mock: MockConfiguration
+    ) {
+        assertMocked(
+            """
+            \(interface.accessLevel) protocol MultiConstraintCollection {
+                #if DEBUG
+                associatedtype Item: Equatable & Sendable
+                #else
+                associatedtype Item: Hashable, Codable
+                #endif
+            }
+            """,
+            generates: """
+            #if SWIFT_MOCKING_ENABLED
+            @MockedMembers
+            \(mock.modifiers)class MultiConstraintCollectionMock<Item> {
+            }
+            #if DEBUG
+            extension MultiConstraintCollectionMock: MultiConstraintCollection where Item: Equatable, Item: Sendable {
+            }
+            #else
+            extension MultiConstraintCollectionMock: MultiConstraintCollection where Item: Hashable, Item: Codable {
+            }
+            #endif
+            #endif
+            """
+        )
+    }
+
     // MARK: OR Condition Tests
 
     @Test(arguments: mockedTestConfigurations)

--- a/Tests/MockingMacrosTests/Macros/MockedMacro/Mocked_IfConfigDeclarationTests.swift
+++ b/Tests/MockingMacrosTests/Macros/MockedMacro/Mocked_IfConfigDeclarationTests.swift
@@ -10,10 +10,10 @@ import Testing
 
 struct Mocked_IfConfigDeclarationTests {
 
-    // MARK: Initializer in #if Block Tests
+    // MARK: Initializers in #if Statement Tests
 
     @Test(arguments: mockedTestConfigurations)
-    func initializerInIfBlock(
+    func initializersInIfStatement(
         interface: InterfaceConfiguration,
         mock: MockConfiguration
     ) {
@@ -42,10 +42,10 @@ struct Mocked_IfConfigDeclarationTests {
         )
     }
 
-    // MARK: Initializer in #if/#else Block Tests
+    // MARK: Initializers in #if/#else Statement Tests
 
     @Test(arguments: mockedTestConfigurations)
-    func initializerInIfElseBlock(
+    func initializersInIfElseStatement(
         interface: InterfaceConfiguration,
         mock: MockConfiguration
     ) {
@@ -76,10 +76,10 @@ struct Mocked_IfConfigDeclarationTests {
         )
     }
 
-    // MARK: Property in #if Block Tests
+    // MARK: Properties in #if Statement Tests
 
     @Test(arguments: mockedTestConfigurations)
-    func propertyInIfBlock(
+    func propertiesInIfStatement(
         interface: InterfaceConfiguration,
         mock: MockConfiguration
     ) {
@@ -108,10 +108,10 @@ struct Mocked_IfConfigDeclarationTests {
         )
     }
 
-    // MARK: Property in #if/#else Block Tests
+    // MARK: Properties in #if/#else Statement Tests
 
     @Test(arguments: mockedTestConfigurations)
-    func propertyInIfElseBlock(
+    func propertiesInIfElseStatement(
         interface: InterfaceConfiguration,
         mock: MockConfiguration
     ) {
@@ -142,10 +142,10 @@ struct Mocked_IfConfigDeclarationTests {
         )
     }
 
-    // MARK: Method in #if Block Tests
+    // MARK: Methods in #if Statement Tests
 
     @Test(arguments: mockedTestConfigurations)
-    func methodInIfBlock(
+    func methodsInIfStatement(
         interface: InterfaceConfiguration,
         mock: MockConfiguration
     ) {
@@ -172,10 +172,10 @@ struct Mocked_IfConfigDeclarationTests {
         )
     }
 
-    // MARK: Method in #if/#else Block Tests
+    // MARK: Methods in #if/#else Statement Tests
 
     @Test(arguments: mockedTestConfigurations)
-    func methodInIfElseBlock(
+    func methodsInIfElseStatement(
         interface: InterfaceConfiguration,
         mock: MockConfiguration
     ) {
@@ -204,41 +204,10 @@ struct Mocked_IfConfigDeclarationTests {
         )
     }
 
-    // MARK: Multiple Members in #if Block Tests
+    // MARK: Methods in #if/#elseif/#else Statement Tests
 
     @Test(arguments: mockedTestConfigurations)
-    func multipleMembersInIfBlock(
-        interface: InterfaceConfiguration,
-        mock: MockConfiguration
-    ) {
-        assertMocked(
-            """
-            \(interface.accessLevel) protocol Dependency {
-                #if DEBUG
-                var debugProperty: Int { get }
-                func debugMethod()
-                #endif
-            }
-            """,
-            generates: """
-            #if SWIFT_MOCKING_ENABLED
-            @MockedMembers
-            \(mock.modifiers)class DependencyMock: Dependency {
-                #if DEBUG
-                @MockableProperty(.readOnly)
-                \(mock.memberModifiers)var debugProperty: Int
-                \(mock.memberModifiers)func debugMethod()
-                #endif
-            }
-            #endif
-            """
-        )
-    }
-
-    // MARK: #if/#elseif/#else Chain Tests
-
-    @Test(arguments: mockedTestConfigurations)
-    func ifElseifElseChain(
+    func methodsInIfElseifElseStatement(
         interface: InterfaceConfiguration,
         mock: MockConfiguration
     ) {
@@ -271,10 +240,10 @@ struct Mocked_IfConfigDeclarationTests {
         )
     }
 
-    // MARK: Associated Type with Same Declaration in #if/#else Block Tests
+    // MARK: Associated Types with Same Declaration in #if/#else Statement Tests
 
     @Test(arguments: mockedTestConfigurations)
-    func associatedTypeWithSameDeclarationInIfElseBlock(
+    func associatedTypesWithSameDeclarationInIfElseStatement(
         interface: InterfaceConfiguration,
         mock: MockConfiguration
     ) {
@@ -298,10 +267,10 @@ struct Mocked_IfConfigDeclarationTests {
         )
     }
 
-    // MARK: Associated Type with Different Constraints in #if/#else Tests
+    // MARK: Associated Types with Different Constraints in #if/#else Statement Tests
 
     @Test(arguments: mockedTestConfigurations)
-    func associatedTypeWithDifferentConstraintsInIfElseBlock(
+    func associatedTypesWithDifferentConstraintsInIfElseStatement(
         interface: InterfaceConfiguration,
         mock: MockConfiguration
     ) {
@@ -332,14 +301,17 @@ struct Mocked_IfConfigDeclarationTests {
         )
     }
 
+    // MARK: Associated Types with Different Constraints in #if/#elseif/#else Statement Tests
+
     @Test(arguments: mockedTestConfigurations)
-    func associatedTypeWithDifferentConstraintsInIfElseifElseChain(
+    func associatedTypesWithDifferentConstraintsInIfElseifElseStatement(
         interface: InterfaceConfiguration,
         mock: MockConfiguration
     ) {
         assertMocked(
             """
-            \(interface.accessLevel) protocol PlatformCollection {
+            \(interface.accessLevel) protocol SomeCollection {
+                associatedtype Key: Hashable
                 #if os(iOS)
                 associatedtype Element: Equatable
                 #elseif os(macOS)
@@ -352,16 +324,16 @@ struct Mocked_IfConfigDeclarationTests {
             generates: """
             #if SWIFT_MOCKING_ENABLED
             @MockedMembers
-            \(mock.modifiers)class PlatformCollectionMock<Element> {
+            \(mock.modifiers)class SomeCollectionMock<Key: Hashable, Element> {
             }
             #if os(iOS)
-            extension PlatformCollectionMock: PlatformCollection where Element: Equatable {
+            extension SomeCollectionMock: SomeCollection where Element: Equatable {
             }
             #elseif os(macOS)
-            extension PlatformCollectionMock: PlatformCollection where Element: Hashable {
+            extension SomeCollectionMock: SomeCollection where Element: Hashable {
             }
             #else
-            extension PlatformCollectionMock: PlatformCollection where Element: Codable {
+            extension SomeCollectionMock: SomeCollection where Element: Codable {
             }
             #endif
             #endif
@@ -369,14 +341,17 @@ struct Mocked_IfConfigDeclarationTests {
         )
     }
 
+    // MARK: Associated Types with Multiple Constraints in #if/#else Statement Tests
+
     @Test(arguments: mockedTestConfigurations)
-    func associatedTypeWithMultipleConstraintsInIfElseBlock(
+    func associatedTypeWithMultipleConstraintsInIfElseStatement(
         interface: InterfaceConfiguration,
         mock: MockConfiguration
     ) {
         assertMocked(
             """
-            \(interface.accessLevel) protocol MultiConstraintCollection {
+            \(interface.accessLevel) protocol SomeCollection {
+                associatedtype Key: Hashable
                 #if DEBUG
                 associatedtype Item: Equatable & Sendable
                 #else
@@ -387,15 +362,127 @@ struct Mocked_IfConfigDeclarationTests {
             generates: """
             #if SWIFT_MOCKING_ENABLED
             @MockedMembers
-            \(mock.modifiers)class MultiConstraintCollectionMock<Item> {
+            \(mock.modifiers)class SomeCollectionMock<Key: Hashable, Item> {
             }
             #if DEBUG
-            extension MultiConstraintCollectionMock: MultiConstraintCollection where Item: Equatable, Item: Sendable {
+            extension SomeCollectionMock: SomeCollection where Item: Equatable & Sendable {
             }
             #else
-            extension MultiConstraintCollectionMock: MultiConstraintCollection where Item: Hashable, Item: Codable {
+            extension SomeCollectionMock: SomeCollection where Item: Hashable & Codable {
             }
             #endif
+            #endif
+            """
+        )
+    }
+
+    // MARK: Associated Types with Different Generic Where Clauses in #if/#else Statement Tests
+
+    @Test(arguments: mockedTestConfigurations)
+    func associatedTypesWithDifferentGenericWhereClausesInIfElseStatement(
+        interface: InterfaceConfiguration,
+        mock: MockConfiguration
+    ) {
+        assertMocked(
+            """
+            \(interface.accessLevel) protocol SomeCollection {
+                associatedtype Key: Hashable
+                #if DEBUG
+                associatedtype Base: RandomAccessCollection & Equatable where Base.Element: Equatable
+                #else
+                associatedtype Base: RandomAccessCollection, Codable where Base.Element: Codable
+                #endif
+            }
+            """,
+            generates: """
+            #if SWIFT_MOCKING_ENABLED
+            @MockedMembers
+            \(mock.modifiers)class SomeCollectionMock<Key: Hashable, Base> {
+            }
+            #if DEBUG
+            extension SomeCollectionMock: SomeCollection \
+            where Base: RandomAccessCollection & Equatable, Base.Element: Equatable {
+            }
+            #else
+            extension SomeCollectionMock: SomeCollection \
+            where Base: RandomAccessCollection & Codable, Base.Element: Codable {
+            }
+            #endif
+            #endif
+            """
+        )
+    }
+
+    // MARK: Associated Types with Different Generic Where Clauses in #if/#elseif/#else Statement Tests
+
+    @Test(arguments: mockedTestConfigurations)
+    func associatedTypesWithDifferentGenericWhereClausesInIfElseifElseStatement(
+        interface: InterfaceConfiguration,
+        mock: MockConfiguration
+    ) {
+        assertMocked(
+            """
+            \(interface.accessLevel) protocol SomeCollection {
+                associatedtype Key: Hashable
+                #if os(iOS)
+                associatedtype Base: RandomAccessCollection where Base.Element: Equatable
+                #elseif os(macOS)
+                associatedtype Base: RandomAccessCollection where Base.Element: Hashable
+                #else
+                associatedtype Base: RandomAccessCollection where Base.Element: Codable
+                #endif
+            }
+            """,
+            generates: """
+            #if SWIFT_MOCKING_ENABLED
+            @MockedMembers
+            \(mock.modifiers)class SomeCollectionMock<Key: Hashable, Base> {
+            }
+            #if os(iOS)
+            extension SomeCollectionMock: SomeCollection \
+            where Base: RandomAccessCollection, Base.Element: Equatable {
+            }
+            #elseif os(macOS)
+            extension SomeCollectionMock: SomeCollection \
+            where Base: RandomAccessCollection, Base.Element: Hashable {
+            }
+            #else
+            extension SomeCollectionMock: SomeCollection \
+            where Base: RandomAccessCollection, Base.Element: Codable {
+            }
+            #endif
+            #endif
+            """
+        )
+    }
+
+
+    // MARK: Multiple Members in #if Statement Tests
+
+    @Test(arguments: mockedTestConfigurations)
+    func multipleMembersInIfStatement(
+        interface: InterfaceConfiguration,
+        mock: MockConfiguration
+    ) {
+        assertMocked(
+            """
+            \(interface.accessLevel) protocol Dependency {
+                #if DEBUG
+                var debugProperty: Int { get }
+                func debugMethod()
+                #endif
+            }
+            """,
+            generates: """
+            #if SWIFT_MOCKING_ENABLED
+            @MockedMembers
+            \(mock.modifiers)class DependencyMock: Dependency {
+                #if DEBUG
+                @MockableProperty(.readOnly)
+                \(mock.memberModifiers)var debugProperty: Int
+                \(mock.memberModifiers)func debugMethod()
+                #endif
+            }
             #endif
             """
         )

--- a/Tests/MockingMacrosTests/Macros/MockedMacro/Mocked_IfConfigDeclarationTests.swift
+++ b/Tests/MockingMacrosTests/Macros/MockedMacro/Mocked_IfConfigDeclarationTests.swift
@@ -456,7 +456,6 @@ struct Mocked_IfConfigDeclarationTests {
         )
     }
 
-
     // MARK: Multiple Members in #if Statement Tests
 
     @Test(arguments: mockedTestConfigurations)

--- a/Tests/MockingMacrosTests/Macros/MockedMacro/Mocked_IfConfigDeclarationTests.swift
+++ b/Tests/MockingMacrosTests/Macros/MockedMacro/Mocked_IfConfigDeclarationTests.swift
@@ -271,10 +271,10 @@ struct Mocked_IfConfigDeclarationTests {
         )
     }
 
-    // MARK: Associated Type in #if Block Tests
+    // MARK: Associated Type with Same Declaration in #if/#else Block Tests
 
     @Test(arguments: mockedTestConfigurations)
-    func associatedTypeInIfBlock(
+    func associatedTypeWithSameDeclarationInIfElseBlock(
         interface: InterfaceConfiguration,
         mock: MockConfiguration
     ) {

--- a/Tests/MockingMacrosTests/Macros/MockedMacro/Mocked_IfConfigDeclarationTests.swift
+++ b/Tests/MockingMacrosTests/Macros/MockedMacro/Mocked_IfConfigDeclarationTests.swift
@@ -1,5 +1,5 @@
 //
-//  Mocked_IfConfigDeclTests.swift
+//  Mocked_IfConfigDeclarationTests.swift
 //
 //  Copyright © 2026 Fetch.
 //
@@ -8,7 +8,7 @@
 import Testing
 @testable import MockingMacros
 
-struct Mocked_IfConfigDeclTests {
+struct Mocked_IfConfigDeclarationTests {
 
     // MARK: Initializer in #if Block Tests
 


### PR DESCRIPTION
## 📝 Summary

Protocols with `#if/#elseif/#else/#endif` blocks now have their members correctly mocked with the conditional compilation structure preserved. This includes support for methods, properties, initializers, and associated types within conditional blocks.

### What changed
- Conditional members are preserved structurally
  - The macro now preserves the full #if/#elseif/#else structure when generating mocked initializers, properties, and methods.
- Associated types under #if are handled safely
  - Associated types declared inside conditional compilation blocks are extracted as generic parameters on the mock.
  - When associated types have branch-specific constraints (inheritance or where clauses), the mock no longer hardcodes a single constraint.
  - Instead, the mock conditionally conforms to the protocol via per-clause extension declarations with the correct where constraints for each branch.
- Associated-type generic where clauses are respected
  - Constraints like where Base.Element: Equatable are now correctly carried into conditional conformance extensions.
- Conditional conformance is only used when necessary
  - If conditional associated types are unconstrained across branches, the mock simply adds the generic parameter and conforms to the protocol unconditionally.

### Known limitations / follow-ups

These cases are intentionally not handled yet and will require a more holistic approach in a future PR:
- Multiple independent top-level #if blocks with constrained associated types
  - Correct handling requires combining constraints across all active branches to avoid duplicate protocol conformances.
- Nested #if blocks containing associated types
  - Supporting this correctly requires recursive traversal and per-configuration constraint aggregation.
- Cross-branch semantic equivalence of constraints
  - The macro does not attempt to detect when constraints are semantically identical but syntactically different (e.g. Equatable & Hashable vs Hashable & Equatable).

These deferred cases all require branch-combination logic and are planned to be addressed together in a follow-up. An issue (#139) has been created to track these edge cases.

## 🛠️ Type of Change

- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds functionality)
- [ ] Breaking change (bug fix or feature that is not backwards compatible)
- [ ] Documentation (DocC, API docs, markdown files, templates, etc.)
- [ ] Testing (new tests, updated tests, etc.)
- [ ] Refactoring or code formatting (no logic changes)
- [ ] Updating dependencies (Swift packages, Homebrew, etc.)
- [ ] CI/CD (change to automated workflows)
- [ ] Chore (other maintenance)

## 🧪 How Has This Been Tested?

- New unit tests have been added.
- All existing unit tests still pass.

## 🔗 Related PRs or Issues <!-- Delete section if not applicable -->

Closes #136

## ✅ Checklist

<!-- Confirm that you've completed the following steps. -->

- [x] I have added relevant tests
- [x] I have verified all tests pass
- [x] I have formatted my code using `SwiftFormat`
- [x] I have updated documentation (if needed)
- [x] I have added the appropriate label to my PR
- [x] I have read the [contributing guidelines](https://github.com/fetch-rewards/swift-mocking/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/fetch-rewards/swift-mocking/blob/main/CODE_OF_CONDUCT.md)
