### PR TITLE
Ensure Package can build with Xcode 27

### DIFF
--- a/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningParameterizedAsyncMethod/MockReturningParameterizedAsyncMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningParameterizedAsyncMethod/MockReturningParameterizedAsyncMethod.swift
@@ -191,7 +191,7 @@ public final class MockReturningParameterizedAsyncMethod<
 // MARK: - Sendable
 
 extension MockReturningParameterizedAsyncMethod: Sendable
-    where Arguments: Sendable, ReturnValue: Sendable
+    where Arguments: Sendable, ReturnValue: Sendable, Implementation: Sendable
 {
 
     // MARK: Factories
@@ -243,7 +243,7 @@ extension MockReturningParameterizedAsyncMethod: Sendable
         closure: @Sendable () -> Closure,
         recordOutput: @Sendable (ReturnValue) -> Void,
         reset: @Sendable () -> Void
-    ) where Arguments: Sendable, ReturnValue: Sendable, Implementation: SendableMetatype {
+    ) {
         let method = MockReturningParameterizedAsyncMethod(
             exposedMethodDescription: exposedMethodDescription
         )

--- a/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningParameterizedAsyncMethod/MockReturningParameterizedAsyncMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningParameterizedAsyncMethod/MockReturningParameterizedAsyncMethod.swift
@@ -243,7 +243,7 @@ extension MockReturningParameterizedAsyncMethod: Sendable
         closure: @Sendable () -> Closure,
         recordOutput: @Sendable (ReturnValue) -> Void,
         reset: @Sendable () -> Void
-    ) {
+    ) where Arguments: Sendable, ReturnValue: Sendable, Implementation: SendableMetatype {
         let method = MockReturningParameterizedAsyncMethod(
             exposedMethodDescription: exposedMethodDescription
         )

--- a/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningParameterizedAsyncThrowingMethod/MockReturningParameterizedAsyncThrowingMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningParameterizedAsyncThrowingMethod/MockReturningParameterizedAsyncThrowingMethod.swift
@@ -199,7 +199,7 @@ public final class MockReturningParameterizedAsyncThrowingMethod<
 // MARK: - Sendable
 
 extension MockReturningParameterizedAsyncThrowingMethod: Sendable
-    where Arguments: Sendable, ReturnValue: Sendable
+    where Arguments: Sendable, ReturnValue: Sendable, Implementation: Sendable
 {
 
     // MARK: Factories
@@ -255,7 +255,7 @@ extension MockReturningParameterizedAsyncThrowingMethod: Sendable
         closure: @Sendable () -> Closure,
         recordOutput: @Sendable (Result<ReturnValue, Error>) -> Void,
         reset: @Sendable () -> Void
-    ) where Arguments: Sendable, ReturnValue: Sendable, Implementation: SendableMetatype {
+    ) {
         let method = MockReturningParameterizedAsyncThrowingMethod(
             exposedMethodDescription: exposedMethodDescription
         )

--- a/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningParameterizedAsyncThrowingMethod/MockReturningParameterizedAsyncThrowingMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningParameterizedAsyncThrowingMethod/MockReturningParameterizedAsyncThrowingMethod.swift
@@ -255,7 +255,7 @@ extension MockReturningParameterizedAsyncThrowingMethod: Sendable
         closure: @Sendable () -> Closure,
         recordOutput: @Sendable (Result<ReturnValue, Error>) -> Void,
         reset: @Sendable () -> Void
-    ) {
+    ) where Arguments: Sendable, ReturnValue: Sendable, Implementation: SendableMetatype {
         let method = MockReturningParameterizedAsyncThrowingMethod(
             exposedMethodDescription: exposedMethodDescription
         )

--- a/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningParameterizedMethod/MockReturningParameterizedMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningParameterizedMethod/MockReturningParameterizedMethod.swift
@@ -243,7 +243,7 @@ extension MockReturningParameterizedMethod: Sendable
         closure: @Sendable () -> Closure,
         recordOutput: @Sendable (ReturnValue) -> Void,
         reset: @Sendable () -> Void
-    ) {
+    ) where Arguments: Sendable, ReturnValue: Sendable, Implementation: SendableMetatype {
         let method = MockReturningParameterizedMethod(
             exposedMethodDescription: exposedMethodDescription
         )

--- a/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningParameterizedMethod/MockReturningParameterizedMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningParameterizedMethod/MockReturningParameterizedMethod.swift
@@ -191,7 +191,7 @@ public final class MockReturningParameterizedMethod<
 // MARK: - Sendable
 
 extension MockReturningParameterizedMethod: Sendable
-    where Arguments: Sendable, ReturnValue: Sendable
+    where Arguments: Sendable, ReturnValue: Sendable, Implementation: Sendable
 {
 
     // MARK: Factories
@@ -243,7 +243,7 @@ extension MockReturningParameterizedMethod: Sendable
         closure: @Sendable () -> Closure,
         recordOutput: @Sendable (ReturnValue) -> Void,
         reset: @Sendable () -> Void
-    ) where Arguments: Sendable, ReturnValue: Sendable, Implementation: SendableMetatype {
+    ) {
         let method = MockReturningParameterizedMethod(
             exposedMethodDescription: exposedMethodDescription
         )

--- a/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningParameterizedThrowingMethod/MockReturningParameterizedThrowingMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningParameterizedThrowingMethod/MockReturningParameterizedThrowingMethod.swift
@@ -254,7 +254,7 @@ extension MockReturningParameterizedThrowingMethod: Sendable
         closure: @Sendable () -> Closure,
         recordOutput: @Sendable (Result<ReturnValue, Error>) -> Void,
         reset: @Sendable () -> Void
-    ) {
+    ) where Arguments: Sendable, ReturnValue: Sendable, Implementation: SendableMetatype {
         let method = MockReturningParameterizedThrowingMethod(
             exposedMethodDescription: exposedMethodDescription
         )

--- a/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningParameterizedThrowingMethod/MockReturningParameterizedThrowingMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockReturningMethods/MockReturningParameterizedThrowingMethod/MockReturningParameterizedThrowingMethod.swift
@@ -198,7 +198,7 @@ public final class MockReturningParameterizedThrowingMethod<
 // MARK: - Sendable
 
 extension MockReturningParameterizedThrowingMethod: Sendable
-    where Arguments: Sendable, ReturnValue: Sendable
+    where Arguments: Sendable, ReturnValue: Sendable, Implementation: Sendable
 {
 
     // MARK: Factories
@@ -254,7 +254,7 @@ extension MockReturningParameterizedThrowingMethod: Sendable
         closure: @Sendable () -> Closure,
         recordOutput: @Sendable (Result<ReturnValue, Error>) -> Void,
         reset: @Sendable () -> Void
-    ) where Arguments: Sendable, ReturnValue: Sendable, Implementation: SendableMetatype {
+    ) {
         let method = MockReturningParameterizedThrowingMethod(
             exposedMethodDescription: exposedMethodDescription
         )

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedAsyncMethod/MockVoidParameterizedAsyncMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedAsyncMethod/MockVoidParameterizedAsyncMethod.swift
@@ -136,7 +136,7 @@ public final class MockVoidParameterizedAsyncMethod<
 
 // MARK: - Sendable
 
-extension MockVoidParameterizedAsyncMethod: Sendable 
+extension MockVoidParameterizedAsyncMethod: Sendable
     where Arguments: Sendable, Implementation: Sendable
 {
 

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedAsyncMethod/MockVoidParameterizedAsyncMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedAsyncMethod/MockVoidParameterizedAsyncMethod.swift
@@ -175,7 +175,7 @@ extension MockVoidParameterizedAsyncMethod: Sendable where Arguments: Sendable {
         recordInput: @Sendable (Arguments) -> Void,
         closure: @Sendable () -> Closure?,
         reset: @Sendable () -> Void
-    ) {
+    ) where Arguments: Sendable, Implementation: SendableMetatype {
         let method = MockVoidParameterizedAsyncMethod()
 
         return (

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedAsyncMethod/MockVoidParameterizedAsyncMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedAsyncMethod/MockVoidParameterizedAsyncMethod.swift
@@ -136,7 +136,7 @@ public final class MockVoidParameterizedAsyncMethod<
 
 // MARK: - Sendable
 
-extension MockVoidParameterizedAsyncMethod: Sendable where Arguments: Sendable {
+extension MockVoidParameterizedAsyncMethod: Sendable where Arguments: Sendable, Implementation: Sendable {
 
     // MARK: Factories
 
@@ -175,7 +175,7 @@ extension MockVoidParameterizedAsyncMethod: Sendable where Arguments: Sendable {
         recordInput: @Sendable (Arguments) -> Void,
         closure: @Sendable () -> Closure?,
         reset: @Sendable () -> Void
-    ) where Arguments: Sendable, Implementation: SendableMetatype {
+    ) {
         let method = MockVoidParameterizedAsyncMethod()
 
         return (

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedAsyncMethod/MockVoidParameterizedAsyncMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedAsyncMethod/MockVoidParameterizedAsyncMethod.swift
@@ -136,7 +136,9 @@ public final class MockVoidParameterizedAsyncMethod<
 
 // MARK: - Sendable
 
-extension MockVoidParameterizedAsyncMethod: Sendable where Arguments: Sendable, Implementation: Sendable {
+extension MockVoidParameterizedAsyncMethod: Sendable where Arguments: Sendable,
+    Implementation: Sendable
+{
 
     // MARK: Factories
 

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedAsyncMethod/MockVoidParameterizedAsyncMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedAsyncMethod/MockVoidParameterizedAsyncMethod.swift
@@ -136,8 +136,8 @@ public final class MockVoidParameterizedAsyncMethod<
 
 // MARK: - Sendable
 
-extension MockVoidParameterizedAsyncMethod: Sendable where Arguments: Sendable,
-    Implementation: Sendable
+extension MockVoidParameterizedAsyncMethod: Sendable 
+    where Arguments: Sendable, Implementation: Sendable
 {
 
     // MARK: Factories

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedAsyncThrowingMethod/MockVoidParameterizedAsyncThrowingMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedAsyncThrowingMethod/MockVoidParameterizedAsyncThrowingMethod.swift
@@ -167,7 +167,9 @@ public final class MockVoidParameterizedAsyncThrowingMethod<
 
 // MARK: - Sendable
 
-extension MockVoidParameterizedAsyncThrowingMethod: Sendable where Arguments: Sendable, Implementation: Sendable {
+extension MockVoidParameterizedAsyncThrowingMethod: Sendable where Arguments: Sendable,
+    Implementation: Sendable
+{
 
     // MARK: Factories
 

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedAsyncThrowingMethod/MockVoidParameterizedAsyncThrowingMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedAsyncThrowingMethod/MockVoidParameterizedAsyncThrowingMethod.swift
@@ -167,7 +167,7 @@ public final class MockVoidParameterizedAsyncThrowingMethod<
 
 // MARK: - Sendable
 
-extension MockVoidParameterizedAsyncThrowingMethod: Sendable where Arguments: Sendable {
+extension MockVoidParameterizedAsyncThrowingMethod: Sendable where Arguments: Sendable, Implementation: Sendable {
 
     // MARK: Factories
 
@@ -212,7 +212,7 @@ extension MockVoidParameterizedAsyncThrowingMethod: Sendable where Arguments: Se
         closure: @Sendable () -> Closure?,
         recordOutput: @Sendable (Error) -> Void,
         reset: @Sendable () -> Void
-    ) where Arguments: Sendable, Implementation: SendableMetatype {
+    ) {
         let method = MockVoidParameterizedAsyncThrowingMethod()
 
         return (

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedAsyncThrowingMethod/MockVoidParameterizedAsyncThrowingMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedAsyncThrowingMethod/MockVoidParameterizedAsyncThrowingMethod.swift
@@ -167,8 +167,8 @@ public final class MockVoidParameterizedAsyncThrowingMethod<
 
 // MARK: - Sendable
 
-extension MockVoidParameterizedAsyncThrowingMethod: Sendable where Arguments: Sendable,
-    Implementation: Sendable
+extension MockVoidParameterizedAsyncThrowingMethod: Sendable 
+    where Arguments: Sendable, Implementation: Sendable
 {
 
     // MARK: Factories

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedAsyncThrowingMethod/MockVoidParameterizedAsyncThrowingMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedAsyncThrowingMethod/MockVoidParameterizedAsyncThrowingMethod.swift
@@ -167,7 +167,7 @@ public final class MockVoidParameterizedAsyncThrowingMethod<
 
 // MARK: - Sendable
 
-extension MockVoidParameterizedAsyncThrowingMethod: Sendable 
+extension MockVoidParameterizedAsyncThrowingMethod: Sendable
     where Arguments: Sendable, Implementation: Sendable
 {
 

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedAsyncThrowingMethod/MockVoidParameterizedAsyncThrowingMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedAsyncThrowingMethod/MockVoidParameterizedAsyncThrowingMethod.swift
@@ -212,7 +212,7 @@ extension MockVoidParameterizedAsyncThrowingMethod: Sendable where Arguments: Se
         closure: @Sendable () -> Closure?,
         recordOutput: @Sendable (Error) -> Void,
         reset: @Sendable () -> Void
-    ) {
+    ) where Arguments: Sendable, Implementation: SendableMetatype {
         let method = MockVoidParameterizedAsyncThrowingMethod()
 
         return (

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedMethod/MockVoidParameterizedMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedMethod/MockVoidParameterizedMethod.swift
@@ -136,7 +136,7 @@ public final class MockVoidParameterizedMethod<
 
 // MARK: - Sendable
 
-extension MockVoidParameterizedMethod: Sendable where Arguments: Sendable {
+extension MockVoidParameterizedMethod: Sendable where Arguments: Sendable, Implementation: Sendable {
 
     // MARK: Factories
 
@@ -175,7 +175,7 @@ extension MockVoidParameterizedMethod: Sendable where Arguments: Sendable {
         recordInput: @Sendable (Arguments) -> Void,
         closure: @Sendable () -> Closure?,
         reset: @Sendable () -> Void
-    ) where Arguments: Sendable, Implementation: SendableMetatype {
+    ) {
         let method = MockVoidParameterizedMethod()
 
         return (

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedMethod/MockVoidParameterizedMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedMethod/MockVoidParameterizedMethod.swift
@@ -136,8 +136,8 @@ public final class MockVoidParameterizedMethod<
 
 // MARK: - Sendable
 
-extension MockVoidParameterizedMethod: Sendable where Arguments: Sendable,
-    Implementation: Sendable
+extension MockVoidParameterizedMethod: Sendable 
+    where Arguments: Sendable, Implementation: Sendable
 {
 
     // MARK: Factories

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedMethod/MockVoidParameterizedMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedMethod/MockVoidParameterizedMethod.swift
@@ -136,7 +136,7 @@ public final class MockVoidParameterizedMethod<
 
 // MARK: - Sendable
 
-extension MockVoidParameterizedMethod: Sendable 
+extension MockVoidParameterizedMethod: Sendable
     where Arguments: Sendable, Implementation: Sendable
 {
 

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedMethod/MockVoidParameterizedMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedMethod/MockVoidParameterizedMethod.swift
@@ -175,7 +175,7 @@ extension MockVoidParameterizedMethod: Sendable where Arguments: Sendable {
         recordInput: @Sendable (Arguments) -> Void,
         closure: @Sendable () -> Closure?,
         reset: @Sendable () -> Void
-    ) {
+    ) where Arguments: Sendable, Implementation: SendableMetatype {
         let method = MockVoidParameterizedMethod()
 
         return (

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedMethod/MockVoidParameterizedMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedMethod/MockVoidParameterizedMethod.swift
@@ -136,7 +136,9 @@ public final class MockVoidParameterizedMethod<
 
 // MARK: - Sendable
 
-extension MockVoidParameterizedMethod: Sendable where Arguments: Sendable, Implementation: Sendable {
+extension MockVoidParameterizedMethod: Sendable where Arguments: Sendable,
+    Implementation: Sendable
+{
 
     // MARK: Factories
 

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedThrowingMethod/MockVoidParameterizedThrowingMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedThrowingMethod/MockVoidParameterizedThrowingMethod.swift
@@ -167,7 +167,9 @@ public final class MockVoidParameterizedThrowingMethod<
 
 // MARK: - Sendable
 
-extension MockVoidParameterizedThrowingMethod: Sendable where Arguments: Sendable, Implementation: Sendable {
+extension MockVoidParameterizedThrowingMethod: Sendable where Arguments: Sendable,
+    Implementation: Sendable
+{
 
     // MARK: Factories
 

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedThrowingMethod/MockVoidParameterizedThrowingMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedThrowingMethod/MockVoidParameterizedThrowingMethod.swift
@@ -212,7 +212,7 @@ extension MockVoidParameterizedThrowingMethod: Sendable where Arguments: Sendabl
         closure: @Sendable () -> Closure?,
         recordOutput: @Sendable (Error) -> Void,
         reset: @Sendable () -> Void
-    ) {
+    ) where Arguments: Sendable, Implementation: SendableMetatype {
         let method = MockVoidParameterizedThrowingMethod()
 
         return (

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedThrowingMethod/MockVoidParameterizedThrowingMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedThrowingMethod/MockVoidParameterizedThrowingMethod.swift
@@ -167,7 +167,7 @@ public final class MockVoidParameterizedThrowingMethod<
 
 // MARK: - Sendable
 
-extension MockVoidParameterizedThrowingMethod: Sendable 
+extension MockVoidParameterizedThrowingMethod: Sendable
     where Arguments: Sendable, Implementation: Sendable
 {
 

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedThrowingMethod/MockVoidParameterizedThrowingMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedThrowingMethod/MockVoidParameterizedThrowingMethod.swift
@@ -167,7 +167,7 @@ public final class MockVoidParameterizedThrowingMethod<
 
 // MARK: - Sendable
 
-extension MockVoidParameterizedThrowingMethod: Sendable where Arguments: Sendable {
+extension MockVoidParameterizedThrowingMethod: Sendable where Arguments: Sendable, Implementation: Sendable {
 
     // MARK: Factories
 
@@ -212,7 +212,7 @@ extension MockVoidParameterizedThrowingMethod: Sendable where Arguments: Sendabl
         closure: @Sendable () -> Closure?,
         recordOutput: @Sendable (Error) -> Void,
         reset: @Sendable () -> Void
-    ) where Arguments: Sendable, Implementation: SendableMetatype {
+    ) {
         let method = MockVoidParameterizedThrowingMethod()
 
         return (

--- a/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedThrowingMethod/MockVoidParameterizedThrowingMethod.swift
+++ b/Sources/Mocking/Models/MockMethods/MockVoidMethods/MockVoidParameterizedThrowingMethod/MockVoidParameterizedThrowingMethod.swift
@@ -167,8 +167,8 @@ public final class MockVoidParameterizedThrowingMethod<
 
 // MARK: - Sendable
 
-extension MockVoidParameterizedThrowingMethod: Sendable where Arguments: Sendable,
-    Implementation: Sendable
+extension MockVoidParameterizedThrowingMethod: Sendable 
+    where Arguments: Sendable, Implementation: Sendable
 {
 
     // MARK: Factories


### PR DESCRIPTION
## 📝 Summary

Addresses #140, the package now builds with compiler versions 6.4 (bundled with Xcode 27) and below .

## 🧪 How Has This Been Tested?

All tests pass, and I manually verified that both Xcode 26.5 and Xcode 27 Beta 1 can build the package and have all tests pass.